### PR TITLE
remove top.terminal_prompt feature, add top.cursor_animation.hide feature

### DIFF
--- a/demo/mkdocs.yml
+++ b/demo/mkdocs.yml
@@ -30,7 +30,7 @@ theme:
     # - navigation.side.hide
     - navigation.side.indexes
     # - navigation.top.hide
-    # - navigation.top.terminal_prompt.hide
+    # - navigation.top.cursor_animation.hide
 
 watch:
     - '../terminal/'

--- a/demo/mkdocs.yml
+++ b/demo/mkdocs.yml
@@ -30,7 +30,7 @@ theme:
     # - navigation.side.hide
     - navigation.side.indexes
     # - navigation.top.hide
-    - navigation.top.terminal_prompt
+    # - navigation.top.terminal_prompt.hide
 
 watch:
     - '../terminal/'

--- a/documentation/docs/index.md
+++ b/documentation/docs/index.md
@@ -12,7 +12,7 @@ theme:
     - navigation.side.hide
     - navigation.side.indexes
     - navigation.top.hide
-    - navigation.top.terminal_prompt
+    - navigation.top.terminal_prompt.hide
 ```
 **toc.hide**  
 hides table of contents on all site pages
@@ -26,8 +26,8 @@ enables section links in side nav.  ignored if `navigation.side.hide` is set.
 **navigation.top.hide**  
 hides top navigation on all site pages
 
-**navigation.top.terminal_prompt**  
-enables terminal prompt site name styling in top nav.  ignored if `navigation.top.hide` is set.
+**navigation.top.terminal_prompt.hide**  
+hides terminal prompt site name styling in top nav.  ignored if `navigation.top.hide` is set.
 
 ## Hideable Components
 In order to hide components on a per-page basis, you need the meta markdown extension

--- a/documentation/docs/index.md
+++ b/documentation/docs/index.md
@@ -12,7 +12,7 @@ theme:
     - navigation.side.hide
     - navigation.side.indexes
     - navigation.top.hide
-    - navigation.top.terminal_prompt.hide
+    - navigation.top.cursor_animation.hide
 ```
 **toc.hide**  
 hides table of contents on all site pages
@@ -26,7 +26,7 @@ enables section links in side nav.  ignored if `navigation.side.hide` is set.
 **navigation.top.hide**  
 hides top navigation on all site pages
 
-**navigation.top.terminal_prompt.hide**  
+**navigation.top.cursor_animation.hide**  
 hides terminal prompt site name styling in top nav.  ignored if `navigation.top.hide` is set.
 
 ## Hideable Components

--- a/documentation/docs/install.md
+++ b/documentation/docs/install.md
@@ -17,6 +17,4 @@ Add `theme` configuration in `mkdocs.yml`:
 ```yaml
 theme:
   name: terminal
-  features:
-    - navigation.top.terminal_prompt
 ```

--- a/documentation/mkdocs.yml
+++ b/documentation/mkdocs.yml
@@ -23,4 +23,4 @@ theme:
     # - navigation.side.hide
     - navigation.side.indexes
     # - navigation.top.hide
-    # - navigation.top.terminal_prompt.hide
+    # - navigation.top.cursor_animation.hide

--- a/documentation/mkdocs.yml
+++ b/documentation/mkdocs.yml
@@ -23,4 +23,4 @@ theme:
     # - navigation.side.hide
     - navigation.side.indexes
     # - navigation.top.hide
-    - navigation.top.terminal_prompt
+    # - navigation.top.terminal_prompt.hide

--- a/terminal/base.html
+++ b/terminal/base.html
@@ -22,7 +22,15 @@
     
     {%- block styles %}
     <link href="{{ 'css/terminal.css' | url }}" rel="stylesheet">
-    <link href="{{ 'css/theme.css' | url }}" rel="stylesheet"> {%- endblock %}
+    <link href="{{ 'css/theme.css' | url }}" rel="stylesheet"> 
+    {% if 'navigation.top.cursor_animation.hide' in features %}
+    <style>
+      .terminal-prompt::after {
+          display: none;
+      }
+    </style> 
+    {% endif %}
+    {%- endblock %}
 
     <!--
     extra_ess contains paths to CSS files in the users

--- a/terminal/css/theme.css
+++ b/terminal/css/theme.css
@@ -18,17 +18,21 @@ body {
     }
 }
 
-/* don't display backticks on `code` items, just highlight */
-code::after,
-code::before {
-    content: "" !important;
-    display: inline;
-}
-
 .terminal-mkdocs-side-nav-item--active {
     font-style: italic;
 }
 
 .terminal-mkdocs-side-nav-item-section-no-index {
     color: var(--secondary-color);
+}
+
+/* ***************************************************************** */
+/* Terminal.css Overrides */
+/* ***************************************************************** */
+
+/* don't display backticks on `code` items, just highlight */
+code::after,
+code::before {
+    content: "" !important;
+    display: inline;
 }

--- a/terminal/partials/top-nav.html
+++ b/terminal/partials/top-nav.html
@@ -1,7 +1,7 @@
 <div class="container">
     <div class="terminal-nav">
         <header class="terminal-logo">
-            <div class="logo {% if 'navigation.top.terminal_prompt' in features %}terminal-prompt{% endif %}"><a href="{% if config.site_url %}{{ config.site_url }}{% else %}/{% endif %}" class="no-style">{{ config.site_name }}</a></div>
+            <div class="logo terminal-prompt"><a href="{% if config.site_url %}{{ config.site_url }}{% else %}/{% endif %}" class="no-style">{{ config.site_name }}</a></div>
         </header>
         <nav class="terminal-menu">
             {% if nav|length>1 %}


### PR DESCRIPTION
- default to displaying terminal cursor animation
- update feature flag to hide terminal cursor animation (instead of removing the entire `terminal-prompt` class)
- #24 