### PR TITLE
jinja2 bug -- convert attr to string before applying string filters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "mkdocs-terminal",
-    "version": "1.2.4",
+    "version": "1.3.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mkdocs-terminal",
-    "version": "1.2.4",
+    "version": "1.3.0",
     "description": "Terminal.css theme for MkDocs",
     "keywords": [
         "mkdocs",

--- a/terminal/macros/tile-image.j2
+++ b/terminal/macros/tile-image.j2
@@ -1,6 +1,6 @@
 {% macro make_image( tile ) -%}
 <img src="{{ tile.img_src }}" 
-    {% if tile.img_title is defined and tile.img_title|length %}title="{{ tile.img_title }}"{% endif %} 
+    {% if tile.img_title is defined and tile.img_title|string|length %}title="{{ tile.img_title }}"{% endif %} 
     alt="{{ tile.img_alt|default('', true ) }}"
     {% if tile.img_width is defined and tile.img_width|string|length %}width="{{ tile.img_width }}"{% endif %} 
     {% if tile.img_height is defined and tile.img_height|string|length %}height="{{ tile.img_height }}"{% endif %} 

--- a/terminal/macros/tile-image.j2
+++ b/terminal/macros/tile-image.j2
@@ -2,7 +2,7 @@
 <img src="{{ tile.img_src }}" 
     {% if tile.img_title is defined and tile.img_title|length %}title="{{ tile.img_title }}"{% endif %} 
     alt="{{ tile.img_alt|default('', true ) }}"
-    {% if tile.img_width is defined and tile.img_width|length %}width="{{ tile.img_width }}"{% endif %} 
-    {% if tile.img_height is defined and tile.img_height|length %}height="{{ tile.img_height }}"{% endif %} 
+    {% if tile.img_width is defined and tile.img_width|string|length %}width="{{ tile.img_width }}"{% endif %} 
+    {% if tile.img_height is defined and tile.img_height|string|length %}height="{{ tile.img_height }}"{% endif %} 
 >
 {%- endmacro -%}

--- a/terminal/macros/tile-link.j2
+++ b/terminal/macros/tile-link.j2
@@ -1,7 +1,7 @@
 {% macro make_link_start( tile ) -%}
 <a  href="{{ tile.link_href }}" 
-    {% if tile.link_title is defined and tile.link_title|length %}title="{{ tile.link_title }}"{% endif %} 
-    {% if tile.link_target is defined and tile.link_target|length %}target="{{ tile.link_target }}"{% endif %} 
+    {% if tile.link_title is defined and tile.link_title|string|length %}title="{{ tile.link_title }}"{% endif %} 
+    {% if tile.link_target is defined and tile.link_target|string|length %}target="{{ tile.link_target }}"{% endif %} 
 >
 {%- endmacro -%}
 

--- a/terminal/macros/tile.j2
+++ b/terminal/macros/tile.j2
@@ -4,13 +4,13 @@
 {% macro make_tile( tile ) -%}
 
 {% set ns = namespace(is_valid=false, has_link=false, has_image=false, has_caption=false) %}
-{% if tile.img_src is defined and tile.img_src|length %}
+{% if tile.img_src is defined and tile.img_src|string|length %}
     {%- set ns.has_image = true -%}
 {% endif %}
-{% if tile.link_href is defined and tile.link_href|length %}
+{% if tile.link_href is defined and tile.link_href|string|length %}
     {%- set ns.has_link = true -%}
 {% endif %}
-{% if tile.caption is defined and tile.caption|length %}
+{% if tile.caption is defined and tile.caption|string|length %}
     {%- set ns.has_caption = true -%}
 {% endif %}
 {% if ns.has_link or ns.has_image %}
@@ -20,7 +20,7 @@
 
 {% if ns.is_valid %}
 <div 
-{% if tile.id is defined and tile.id|length %} 
+{% if tile.id is defined and tile.id|string|length %} 
 id="{{ tile.id }}" 
 {% endif %}
 class="terminal-mkdocs-tile {{ tile.class }}">
@@ -42,7 +42,7 @@ class="terminal-mkdocs-tile {{ tile.class }}">
         {% endif %}
         
         {% if ns.has_caption %}
-            <figcaption>{{ tile.caption|trim}}</figcaption>
+            <figcaption>{{ tile.caption|string|trim }}</figcaption>
         {% endif %}
     </figure>
 </div>

--- a/terminal/theme_version.html
+++ b/terminal/theme_version.html
@@ -1,1 +1,1 @@
-<meta name="generator" content="mkdocs-{{ mkdocs_version }}, mkdocs-terminal-1.2.4">
+<meta name="generator" content="mkdocs-{{ mkdocs_version }}, mkdocs-terminal-1.3.0">

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,6 +53,11 @@ def minimal_linked_image_tile():
     return Tile(link_href=defaults.GITHUB_LINK_HREF, img_src=defaults.GITHUB_IMG_SRC)
 
 
+@pytest.fixture
+def all_integer_tile():
+    return Tile(caption=0, html_id=1, css_class=2, link_text=3, link_href=4, link_title=5, link_target=6, img_src=7, img_alt=8, img_title=9, img_width=10, img_height=11)
+
+
 # @pytest.fixture
 # def dict_loader():
 #     """returns DictLoader"""

--- a/tests/test_tile.py
+++ b/tests/test_tile.py
@@ -61,10 +61,9 @@ class TestTile():
         assert "class=\"terminal-mkdocs-tile myClass\"" in rendered_tile
         assert len(check_html(rendered_tile)["errors"]) == 0
 
-    def test_that_tile_renders_with_integer_inputs(self, env_with_terminal_loader):
-        tile = Tile(html_id=1, css_class=2, caption=3, link_href=4, link_title=5, link_target=6, img_src=7, img_alt=8, img_title=9, img_width=10, img_height=11)
+    def test_that_tile_renders_with_integer_inputs(self, env_with_terminal_loader, all_integer_tile):
         tile_macro = env_with_terminal_loader.get_template("macros/tile.j2")
         try:
-            tile_macro.module.make_tile(tile)
+            tile_macro.module.make_tile(all_integer_tile)
         except Exception as ex:
-            pytest.fail(f"Got exception during tile render: {ex})")
+            pytest.fail(f"Got exception during render: {ex})")

--- a/tests/test_tile.py
+++ b/tests/test_tile.py
@@ -64,5 +64,7 @@ class TestTile():
     def test_that_tile_renders_with_integer_inputs(self, env_with_terminal_loader):
         tile = Tile(html_id=1, css_class=2, caption=3, link_href=4, link_title=5, link_target=6, img_src=7, img_alt=8, img_title=9, img_width=10, img_height=11)
         tile_macro = env_with_terminal_loader.get_template("macros/tile.j2")
-        rendered_tile = tile_macro.module.make_tile(tile)
-        assert len(check_html(rendered_tile)["errors"]) == 0
+        try:
+            tile_macro.module.make_tile(tile)
+        except Exception as ex:
+            pytest.fail(f"Got exception during tile render: {ex})")

--- a/tests/test_tile.py
+++ b/tests/test_tile.py
@@ -60,3 +60,9 @@ class TestTile():
         assert "id=\"myID\"" in rendered_tile
         assert "class=\"terminal-mkdocs-tile myClass\"" in rendered_tile
         assert len(check_html(rendered_tile)["errors"]) == 0
+
+    def test_that_tile_renders_with_integer_inputs(self, env_with_terminal_loader):
+        tile = Tile(html_id=1, css_class=2, caption=3, link_href=4, link_title=5, link_target=6, img_src=7, img_alt=8, img_title=9, img_width=10, img_height=11)
+        tile_macro = env_with_terminal_loader.get_template("macros/tile.j2")
+        rendered_tile = tile_macro.module.make_tile(tile)
+        assert len(check_html(rendered_tile)["errors"]) == 0

--- a/tests/test_tile_image.py
+++ b/tests/test_tile_image.py
@@ -40,10 +40,9 @@ class TestTileImage():
         rendered_image = image_macro.module.make_image(tile)
         assert len(check_html(rendered_image)["errors"]) == 0
 
-    def test_that_img_tile_renders_with_integer_inputs(self, env_with_terminal_loader):
-        tile = Tile(img_src=1, img_alt=2, img_title=3, img_width=100, img_height=200)
+    def test_that_img_tile_renders_with_integer_inputs(self, env_with_terminal_loader, all_integer_tile):
         image_macro = env_with_terminal_loader.get_template("macros/tile-image.j2")
         try:
-            image_macro.module.make_image(tile)
+            image_macro.module.make_image(all_integer_tile)
         except Exception as ex:
-            pytest.fail(f"Got exception during tile render: {ex})")
+            pytest.fail(f"Got exception during render: {ex})")

--- a/tests/test_tile_image.py
+++ b/tests/test_tile_image.py
@@ -38,3 +38,9 @@ class TestTileImage():
         image_macro = env_with_terminal_loader.get_template("macros/tile-image.j2")
         rendered_image = image_macro.module.make_image(tile)
         assert len(check_html(rendered_image)["errors"]) == 0
+
+    def test_that_img_tile_renders_with_integer_inputs(self, env_with_terminal_loader):
+        tile = Tile(img_src=1, img_alt=2, img_title=3, img_width=100, img_height=200)
+        image_macro = env_with_terminal_loader.get_template("macros/tile-image.j2")
+        rendered_image = image_macro.module.make_image(tile)
+        assert len(check_html(rendered_image)["errors"]) == 0

--- a/tests/test_tile_image.py
+++ b/tests/test_tile_image.py
@@ -1,6 +1,7 @@
 from tests.utils.tile import Tile
 from tests.utils.html import check_html
 from tests import defaults
+import pytest
 
 
 class TestTileImage():
@@ -42,5 +43,7 @@ class TestTileImage():
     def test_that_img_tile_renders_with_integer_inputs(self, env_with_terminal_loader):
         tile = Tile(img_src=1, img_alt=2, img_title=3, img_width=100, img_height=200)
         image_macro = env_with_terminal_loader.get_template("macros/tile-image.j2")
-        rendered_image = image_macro.module.make_image(tile)
-        assert len(check_html(rendered_image)["errors"]) == 0
+        try:
+            image_macro.module.make_image(tile)
+        except Exception as ex:
+            pytest.fail(f"Got exception during tile render: {ex})")

--- a/tests/test_tile_image.py
+++ b/tests/test_tile_image.py
@@ -32,3 +32,9 @@ class TestTileImage():
         assert "width=\"" + defaults.GITHUB_IMG_WIDTH + "\"" in rendered_image
         assert "height=\"" + defaults.GITHUB_IMG_HEIGHT + "\"" in rendered_image
         assert len(check_html(rendered_image)["errors"]) == 0
+
+    def test_that_img_tile_renders_for_integer_width_and_height(self, env_with_terminal_loader):
+        tile = Tile(img_width=100, img_height=200, img_src=defaults.GITHUB_IMG_SRC)
+        image_macro = env_with_terminal_loader.get_template("macros/tile-image.j2")
+        rendered_image = image_macro.module.make_image(tile)
+        assert len(check_html(rendered_image)["errors"]) == 0

--- a/tests/test_tile_link.py
+++ b/tests/test_tile_link.py
@@ -1,12 +1,17 @@
-from tests.utils.tile import Tile
+from tests import defaults
+import pytest
 
 
 class TestTileLinkHelper():
 
-    def test_helper_with_minimal_link_only_tile(self, env, filesystem_terminal_loader):
-        env.loader = filesystem_terminal_loader
-        tile_link_macro = env.get_template("macros/tile-link.j2")
+    def test_helper_with_minimal_link_only_tile(self, env_with_terminal_loader, minimal_link_tile):
+        tile_link_macro = env_with_terminal_loader.get_template("macros/tile-link.j2")
+        rendered_link_start = tile_link_macro.module.make_link_start(minimal_link_tile)
+        assert defaults.GITHUB_LINK_HREF in rendered_link_start
 
-        t = Tile(link_href="https://example.com")
-        rendered_link_start = tile_link_macro.module.make_link_start(t)
-        assert t.link_href in rendered_link_start
+    def test_that_link_start_fragment_renders_with_integer_inputs(self, env_with_terminal_loader, all_integer_tile):
+        link_macro = env_with_terminal_loader.get_template("macros/tile-link.j2")
+        try:
+            link_macro.module.make_link_start(all_integer_tile)
+        except Exception as ex:
+            pytest.fail(f"Got exception during render: {ex})")

--- a/tests/utils/tile.py
+++ b/tests/utils/tile.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Optional
+from typing import Optional, Any
 
 log = logging.getLogger(__name__)
 
@@ -32,38 +32,38 @@ class Tile:
             self.img_src is not None) else '[blank]'
         return f"Tile(caption={caption}, link_href={link_href}, img_src='{img_src}')"
 
-    caption: Optional[str]
+    caption: Optional[Any]
     """The figure caption."""
 
-    img_src: Optional[str]
+    img_src: Optional[Any]
     """The image source.  Can be an external image like `https://picsum.photos/id/167/200/200` or an internal MkDocs image like `../img/palettes/default.png`."""
 
-    img_title: Optional[str]
+    img_title: Optional[Any]
     """Text to display on hover."""
 
-    img_alt: Optional[str]
+    img_alt: Optional[Any]
     """Alternate text for the image if the image cannot be displayed."""
 
-    img_width: Optional[str]
+    img_width: Optional[Any]
     """Width to set on the image element."""
 
-    img_height: Optional[str]
+    img_height: Optional[Any]
     """Height to set on the image element."""
 
-    link_href: Optional[str]
+    link_href: Optional[Any]
     """Web page URL.  Can be an external web page or an internal MkDocs page like `./default/`."""
 
-    link_target: Optional[str]
+    link_target: Optional[Any]
     """Specifies where to open the linked webpage.  `_blank` will open the link in a new tab.  `_self` will open the link in the current window."""
 
-    link_text: Optional[str]
+    link_text: Optional[Any]
     """Text to display for a [link only] tile.  Ignored if `img_src` is specified."""
 
-    link_title: Optional[str]
+    link_title: Optional[Any]
     """Text to display on hover.  Should not be used if `img_title` is already specified."""
 
-    html_id: Optional[str]
+    html_id: Optional[Any]
     """ID to add to the tile's HTML for advanced styling."""
 
-    css_class: Optional[str]
+    css_class: Optional[Any]
     """CSS class to add to the tile's HTML for advanced styling."""


### PR DESCRIPTION
ran into issue where jinja2 throws exception when rendering
tile templates use `length` filter which fails when an attribute is not a string
we need to convert the attributes to string before using string filters (length, trim, etc.)


### Testing

added unit tests, checked that doc site renders locally

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in [mkdocs-terminal/documentation](https://github.com/ntno/mkdocs-terminal/tree/main/documentation/docs)
- [x] All active GitHub checks for tests, formatting, and security are passing

