### PR TITLE
Return to site url if available

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "mkdocs-terminal",
-    "version": "3.1.1",
+    "version": "3.1.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mkdocs-terminal",
-    "version": "3.1.1",
+    "version": "3.1.2",
     "description": "Terminal.css theme for MkDocs",
     "keywords": [
         "mkdocs",

--- a/terminal/404.html
+++ b/terminal/404.html
@@ -5,5 +5,5 @@
 {% block content_container %}
 <br>
 <div class="terminal-alert terminal-alert-error">The page you requested could not be found.</div>
-<a href="/"><button class="btn btn-default">Return Home</button></a>
+<a href="{% if config.site_url %}{{ config.site_url }}{% else %}/{% endif %}"><button class="btn btn-default">Return Home</button></a>
 {% endblock %}

--- a/terminal/theme_version.html
+++ b/terminal/theme_version.html
@@ -1,1 +1,1 @@
-<meta name="generator" content="mkdocs-{{ mkdocs_version }}, mkdocs-terminal-3.1.1">
+<meta name="generator" content="mkdocs-{{ mkdocs_version }}, mkdocs-terminal-3.1.2">


### PR DESCRIPTION
bug fix for 404 static template
if site_url is available, use that url in the 'return home' button
fall back to /
