### PR TITLE
update section-indexes docs page

### DIFF
--- a/documentation/docs/navigation/section-indexes.md
+++ b/documentation/docs/navigation/section-indexes.md
@@ -3,7 +3,7 @@
 When the section index theme feature is enabled, documents can be directly attached to sections.  This is particularly useful for providing overview pages. 
 
 ## Example Scenario
-Let's say you have a site with 'Release Notes' and 'About' sections.  The 'Release Notes' section is nested inside the 'About' section and each section contains an overview page.
+Let's say you have a site with *Release Notes* and *About* documents.  The *Release Notes* documents are a subsection of the *About* section.  Both sections contain an overview page:
 
 <figure markdown>
 ```directory
@@ -18,19 +18,19 @@ Let's say you have a site with 'Release Notes' and 'About' sections.  The 'Relea
 │  │  ├─ license.md
 │  │  └─ contributing.md
 │  ├─ index.md                # Home
-│  └─ troubleshooting.md
+│  └─ help.md
 ├─ requirements.txt
 └─ mkdocs.yml
 ```
-<figcaption></figcaption>
+<figcaption markdown>The *Release Notes* section is inside the *About* section.<br>Each section has an overview page.</figcaption>
 </figure>
 
-## With Section Indexes
+## With Section Indexes Feature
 *About* and *Release Notes* are clickable in the side navigation.  The index page for the *About* section does not appear as a subpage of the *About* category:
 
 ![Section index pages enabled](../img/about_page_with_section_indexes.png){title="'About' and 'Release Notes' are clickable in the side navigation"; alt="'Release Notes' is rendered as a clickable link in the side navigation" .terminal-mkdocs-thin-border}
 
-## Without Section Indexes
+## Without Section Indexes Feature
 *About* and *Release Notes* are not clickable in the side navigation.  Instead, they are rendered as greyed out text.  The index page for the *About* section appears as a subpage of the *About* category:
 
 ![Section index pages enabled](../img/about_page_without_section_indexes.png){title="'About' and 'Release Notes' are not clickable in the side navigation"; alt="'Release Notes' is rendered as greyed out text in the side navigation" .terminal-mkdocs-thin-border}

--- a/documentation/docs/navigation/section-indexes.md
+++ b/documentation/docs/navigation/section-indexes.md
@@ -48,6 +48,9 @@ Let's say you have a site with *Release Notes* and *About* documents.  The *Rele
 
 2. Add a page with the title 'Index' as a subpage in the `nav` config in `mkdocs.yml`:
 
+      <figure markdown>
+
+
         nav:
             - Home: 'index.md'
             - Troubleshooting: 'help.md'
@@ -60,5 +63,7 @@ Let's say you have a site with *Release Notes* and *About* documents.  The *Rele
                 - v1: 'about/release-notes/version-1.md'
                 - v2: 'about/release-notes/version-2.md'
 
+      <figcaption markdown>Use the page title 'Index' for section indexes.</figcaption>
+      </figure>
 
 

--- a/documentation/docs/navigation/section-indexes.md
+++ b/documentation/docs/navigation/section-indexes.md
@@ -28,12 +28,12 @@ Let's say you have a site with *Release Notes* and *About* documents.  The *Rele
 ## With Section Indexes Feature
 *About* and *Release Notes* are clickable in the side navigation.  The index page for the *About* section does not appear as a subpage of the *About* category:
 
-![Section index pages enabled](../img/about_page_with_section_indexes.png){title="'About' and 'Release Notes' are clickable in the side navigation"; alt="'Release Notes' is rendered as a clickable link in the side navigation" .terminal-mkdocs-thin-border}
+![section index pages enabled](../img/about_page_with_section_indexes.png){alt="'Release Notes' is rendered as a clickable link in the side navigation" .terminal-mkdocs-thin-border}
 
 ## Without Section Indexes Feature
 *About* and *Release Notes* are not clickable in the side navigation.  Instead, they are rendered as greyed out text.  The index page for the *About* section appears as a subpage of the *About* category:
 
-![Section index pages enabled](../img/about_page_without_section_indexes.png){title="'About' and 'Release Notes' are not clickable in the side navigation"; alt="'Release Notes' is rendered as greyed out text in the side navigation" .terminal-mkdocs-thin-border}
+![section index pages enabled](../img/about_page_without_section_indexes.png){alt="'Release Notes' is rendered as greyed out text in the side navigation" .terminal-mkdocs-thin-border}
 
 
 # Setup

--- a/documentation/docs/navigation/section-indexes.md
+++ b/documentation/docs/navigation/section-indexes.md
@@ -2,6 +2,19 @@
 
 When the section index theme feature is enabled, documents can be directly attached to sections.  This is particularly useful for providing overview pages. 
 
+## Examples
+
+## With Section Indexes
+*About* and *Release Notes* are clickable in the side navigation.  The index page for the *About* section does not appear as a subpage of the *About* category:
+
+![Section index pages enabled](../img/about_page_with_section_indexes.png){title="'About' and 'Release Notes' are clickable in the side navigation"; alt="'Release Notes' is rendered as a clickable link in the side navigation" .terminal-mkdocs-thin-border}
+
+## Without Section Indexes
+*About* and *Release Notes* are not clickable in the side navigation.  Instead, they are rendered as greyed out text.  The index page for the *About* section appears as a subpage of the *About* category:
+
+![Section index pages enabled](../img/about_page_without_section_indexes.png){title="'About' and 'Release Notes' are not clickable in the side navigation"; alt="'Release Notes' is rendered as greyed out text in the side navigation" .terminal-mkdocs-thin-border}
+
+
 ## Setup
 1. Add the `navigation.side.indexes` feature to the theme configuration in `mkdocs.yml`:
 
@@ -26,16 +39,5 @@ When the section index theme feature is enabled, documents can be directly attac
                 - v1: 'about/release-notes/version-1.md'
                 - v2: 'about/release-notes/version-2.md'
 
-## Examples
-
-## With Section Indexes
-*About* and *Release Notes* are clickable in the side navigation.  The index page for the *About* section does not appear as a subpage of the *About* category:
-
-![Section index pages enabled](../img/about_page_with_section_indexes.png){title="'About' and 'Release Notes' are clickable in the side navigation"; alt="'Release Notes' is rendered as a clickable link in the side navigation" .terminal-mkdocs-thin-border}
-
-## Without Section Indexes
-*About* and *Release Notes* are not clickable in the side navigation.  Instead, they are rendered as greyed out text.  The index page for the *About* section appears as a subpage of the *About* category:
-
-![Section index pages enabled](../img/about_page_without_section_indexes.png){title="'About' and 'Release Notes' are not clickable in the side navigation"; alt="'Release Notes' is rendered as greyed out text in the side navigation" .terminal-mkdocs-thin-border}
 
 

--- a/documentation/docs/navigation/section-indexes.md
+++ b/documentation/docs/navigation/section-indexes.md
@@ -2,7 +2,28 @@
 
 When the section index theme feature is enabled, documents can be directly attached to sections.  This is particularly useful for providing overview pages. 
 
-## Examples
+## Example Scenario
+Let's say you have a site with 'Release Notes' and 'About' sections.  The 'Release Notes' section is nested inside the 'About' section and each section contains an overview page.
+
+<figure markdown>
+```directory
+.
+├─ docs/
+│  ├─ about/
+│  │  ├─ release-notes/
+│  │  │  ├─ index.md          # Release Notes Overview
+│  │  │  ├─ version-1.md
+│  │  │  └─ version-2.md
+│  │  ├─ index.md             # About Overview
+│  │  ├─ license.md
+│  │  └─ contributing.md
+│  ├─ index.md                # Home
+│  └─ troubleshooting.md
+├─ requirements.txt
+└─ mkdocs.yml
+```
+<figcaption></figcaption>
+</figure>
 
 ## With Section Indexes
 *About* and *Release Notes* are clickable in the side navigation.  The index page for the *About* section does not appear as a subpage of the *About* category:
@@ -15,7 +36,7 @@ When the section index theme feature is enabled, documents can be directly attac
 ![Section index pages enabled](../img/about_page_without_section_indexes.png){title="'About' and 'Release Notes' are not clickable in the side navigation"; alt="'Release Notes' is rendered as greyed out text in the side navigation" .terminal-mkdocs-thin-border}
 
 
-## Setup
+# Setup
 1. Add the `navigation.side.indexes` feature to the theme configuration in `mkdocs.yml`:
 
         

--- a/documentation/mkdocs.yml
+++ b/documentation/mkdocs.yml
@@ -103,6 +103,7 @@ theme:
     - navigation.side.indexes
     - revision.date
     - revision.history
+    - style.links.underline.hide
   static_templates:
     - 404.html
     - about/coverage-report/index.html

--- a/documentation/requirements.txt
+++ b/documentation/requirements.txt
@@ -1,5 +1,5 @@
 mkdocs
-mkdocs-terminal>=3.8.2
+mkdocs-terminal>=3.10.0
 
 # Python Markdown Extensions
 pygments>=2.14

--- a/notes/NOTES.md
+++ b/notes/NOTES.md
@@ -47,7 +47,8 @@ Terminal for MkDocs' Tile Grid relies on the *meta*[^mkdocs-page-meta] attribute
   - `npm install broken-link-checker -g`
   - `blc http://localhost:8080 -ro`
 - [YAML boolean syntax](https://yaml.org/spec/1.2.2/#10212-boolean)  
-  
+- [ascii directory tree generator](https://ascii-tree-generator.com/)
+
 ## regex
 ### linked image
 `<div .*? <figure(.)[^>]*? <a(.)*<img`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "mkdocs-terminal",
-    "version": "3.10.0",
+    "version": "3.10.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mkdocs-terminal",
-    "version": "3.10.0",
+    "version": "3.10.1",
     "description": "Terminal.css theme for MkDocs",
     "keywords": [
         "mkdocs",

--- a/terminal/theme_version.html
+++ b/terminal/theme_version.html
@@ -1,1 +1,1 @@
-<meta name="generator" content="mkdocs-{{ mkdocs_version }}, mkdocs-terminal-3.10.0">
+<meta name="generator" content="mkdocs-{{ mkdocs_version }}, mkdocs-terminal-3.10.1">


### PR DESCRIPTION
improve documentation on section-indexes
- move examples above setup instructions
- add example scenario directory structure
- add figcaptions

disable link underlines for docs site (temporary until links can be reviewed; some pages have too many links and it is hard to read with them underlined)