### PR TITLE
Remove link targets

### DIFF
--- a/documentation/docs/configuration/blocks.md
+++ b/documentation/docs/configuration/blocks.md
@@ -2,7 +2,7 @@
 
 In some situations you may want to include your own Jinja2 page templates.  Terminal for MkDocs supports overriding or extending the blocks listed in [Reference](blocks.md#overridable-blocks).  
 
-This is an advanced MkDocs feature.  For an extended discussion, see the [official MkDocs guide]{target="_blank"}.
+This is an advanced MkDocs feature.  For an extended discussion, see the [official MkDocs guide].
 
 
 [official MkDocs guide]: https://www.mkdocs.org/user-guide/customizing-your-theme/#using-the-theme-custom_dir

--- a/documentation/docs/configuration/extensions/index.md
+++ b/documentation/docs/configuration/extensions/index.md
@@ -5,7 +5,7 @@ configuration/extensions/links.md
 # Extensions
 
 Markdown is a very small language with a kind-of reference implementation called
-[John Gruber's Markdown]{target="_blank"}. [Python Markdown]{target="_blank"} and [PyMdown Extensions]{target="_blank"} are two packages that enhance the Markdown writing experience, adding useful syntax extensions for technical writing.
+[John Gruber's Markdown]. [Python Markdown] and [PyMdown Extensions] are two packages that enhance the Markdown writing experience, adding useful syntax extensions for technical writing.
 
   [John Gruber's Markdown]: https://daringfireball.net/projects/markdown/
   [Python Markdown]: https://python-markdown.github.io/extensions/
@@ -106,4 +106,4 @@ markdown_extensions:
 ```
 
 # Credit
-This documentation page is based on squidfunk's Material for MkDocs [Extensions](https://squidfunk.github.io/mkdocs-material/setup/extensions/){target="_blank"} documentation.
+This documentation page is based on squidfunk's Material for MkDocs [Extensions](https://squidfunk.github.io/mkdocs-material/setup/extensions/) documentation.

--- a/documentation/docs/configuration/extensions/py-mdown-extensions.md
+++ b/documentation/docs/configuration/extensions/py-mdown-extensions.md
@@ -15,7 +15,7 @@ installed with a supported version.
 
 ## Caret, Mark & Tilde
 
-The [Caret], [Mark] and [Tilde] extensions add the ability to highlight text
+The [Caret], [Mark], and [Tilde] extensions add the ability to highlight text
 and define subscript and superscript using a simple syntax. Enable them together
 via `mkdocs.yml`:
 

--- a/documentation/docs/configuration/extensions/py-mdown-extensions.md
+++ b/documentation/docs/configuration/extensions/py-mdown-extensions.md
@@ -4,7 +4,7 @@ configuration/extensions/links.md
 
 # PyMdown Extensions
 
-The [PyMdown Extensions]{target="_blank"} package is an excellent collection of
+The [PyMdown Extensions] package is an excellent collection of
 additional extensions perfectly suited for advanced technical writing. Terminal
 for MkDocs lists this package as an explicit dependency so it's automatically
 installed with a supported version.
@@ -15,7 +15,7 @@ installed with a supported version.
 
 ## Caret, Mark & Tilde
 
-The [Caret]{target="_blank"}, [Mark]{target="_blank"} and [Tilde]{target="_blank"} extensions add the ability to highlight text
+The [Caret], [Mark] and [Tilde] extensions add the ability to highlight text
 and define subscript and superscript using a simple syntax. Enable them together
 via `mkdocs.yml`:
 
@@ -47,7 +47,7 @@ See reference for usage:
 
 ## Snippets
 
-The [Snippets]{target="_blank"} extension adds the ability to embed content from arbitrary files into a document, including other documents or source files, by using a simple syntax. Enable it via `mkdocs.yml`:
+The [Snippets] extension adds the ability to embed content from arbitrary files into a document, including other documents or source files, by using a simple syntax. Enable it via `mkdocs.yml`:
 
 ``` yaml
 markdown_extensions:
@@ -56,7 +56,7 @@ markdown_extensions:
 
 The configuration options of this extension are not specific to Terminal for
 MkDocs, as they only impact the Markdown parsing stage. See the [Snippets 
-documentation][Snippets]{target="_blank"} for more information.
+documentation][Snippets] for more information.
 
   [Snippets]: https://facelessuser.github.io/pymdown-extensions/extensions/snippets/
   
@@ -69,4 +69,4 @@ See reference for usage:
 
 # Credit
 
-This documentation page is based on squidfunk's Material for MkDocs [Pymdown Extension](https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown-extensions/){target="_blank"} documentation.
+This documentation page is based on squidfunk's Material for MkDocs [Pymdown Extension](https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown-extensions/) documentation.

--- a/documentation/docs/configuration/extensions/pymdown-extensions.md
+++ b/documentation/docs/configuration/extensions/pymdown-extensions.md
@@ -15,7 +15,7 @@ installed with a supported version.
 
 ## Caret, Mark & Tilde
 
-The [Caret], [Mark] and [Tilde] extensions add the ability to highlight text
+The [Caret], [Mark], and [Tilde] extensions add the ability to highlight text
 and define subscript and superscript using a simple syntax. Enable them together
 via `mkdocs.yml`:
 

--- a/documentation/docs/configuration/extensions/pymdown-extensions.md
+++ b/documentation/docs/configuration/extensions/pymdown-extensions.md
@@ -4,7 +4,7 @@ configuration/extensions/links.md
 
 # PyMdown Extensions
 
-The [PyMdown Extensions]{target="_blank"} package is an excellent collection of
+The [PyMdown Extensions] package is an excellent collection of
 additional extensions perfectly suited for advanced technical writing. Terminal
 for MkDocs lists this package as an explicit dependency so it's automatically
 installed with a supported version.
@@ -15,7 +15,7 @@ installed with a supported version.
 
 ## Caret, Mark & Tilde
 
-The [Caret]{target="_blank"}, [Mark]{target="_blank"} and [Tilde]{target="_blank"} extensions add the ability to highlight text
+The [Caret], [Mark] and [Tilde] extensions add the ability to highlight text
 and define subscript and superscript using a simple syntax. Enable them together
 via `mkdocs.yml`:
 
@@ -47,7 +47,7 @@ See reference for usage:
 
 ## Snippets
 
-The [Snippets]{target="_blank"} extension adds the ability to embed content from arbitrary files into a document, including other documents or source files, by using a simple syntax. Enable it via `mkdocs.yml`:
+The [Snippets] extension adds the ability to embed content from arbitrary files into a document, including other documents or source files, by using a simple syntax. Enable it via `mkdocs.yml`:
 
 ``` yaml
 markdown_extensions:
@@ -56,7 +56,7 @@ markdown_extensions:
 
 The configuration options of this extension are not specific to Terminal for
 MkDocs, as they only impact the Markdown parsing stage. See the [Snippets 
-documentation][Snippets]{target="_blank"} for more information.
+documentation][Snippets] for more information.
 
   [Snippets]: https://facelessuser.github.io/pymdown-extensions/extensions/snippets/
   
@@ -69,4 +69,4 @@ See reference for usage:
 
 # Credit
 
-This documentation page is based on squidfunk's Material for MkDocs [Pymdown Extension](https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown-extensions/){target="_blank"} documentation.
+This documentation page is based on squidfunk's Material for MkDocs [Pymdown Extension](https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown-extensions/) documentation.

--- a/documentation/docs/configuration/extensions/python-markdown.md
+++ b/documentation/docs/configuration/extensions/python-markdown.md
@@ -4,7 +4,7 @@ configuration/extensions/links.md
 
 # Python Markdown
 
-Terminal for MkDocs is compatible with some of the [Python Markdown]{target="_blank"} extensions. The following is a list of all extensions which have been tested with this theme, linking to documentation which explain how they can be used.
+Terminal for MkDocs is compatible with some of the [Python Markdown] extensions. The following is a list of all extensions which have been tested with this theme, linking to documentation which explain how they can be used.
 
   [Python Markdown]: https://python-markdown.github.io/extensions/
 
@@ -12,7 +12,7 @@ Terminal for MkDocs is compatible with some of the [Python Markdown]{target="_bl
 
 ## Attribute Lists
 
-The [Attribute Lists]{target="_blank"} extension helps to add HTML attributes and CSS classes to [almost every][Attribute Lists limitations]{target="_blank"} Markdown inline- and block-level element with a special syntax. Enable it via `mkdocs.yml`:
+The [Attribute Lists] extension helps to add HTML attributes and CSS classes to [almost every][Attribute Lists limitations] Markdown inline- and block-level element with a special syntax. Enable it via `mkdocs.yml`:
 
 ``` yaml
 markdown_extensions:
@@ -33,8 +33,8 @@ No configuration options are available. See reference for usage:
 
 ## Definition Lists
 
-The [Definition Lists]{target="_blank"} extension adds the ability to add definition lists (more
-commonly known as [description lists]{target="_blank"} – `dl` in HTML) via Markdown to a
+The [Definition Lists] extension adds the ability to add definition lists (more
+commonly known as [description lists] – `dl` in HTML) via Markdown to a
 document. Enable it via `mkdocs.yml`:
 
 ``` yaml
@@ -52,7 +52,7 @@ No configuration options are available. See reference for usage:
 
 ## Footnotes
 
-The [Footnotes]{target="_blank"} extension enables inline footnotes which are then
+The [Footnotes] extension enables inline footnotes which are then
 rendered below all Markdown content of a document. Enable it via `mkdocs.yml`:
 
 ``` yaml
@@ -71,7 +71,7 @@ No configuration options are supported. See reference for usage:
 
 ## Markdown in HTML
 
-The [Markdown in HTML]{target="_blank"} extension allows for writing Markdown inside of HTML, which is useful for wrapping Markdown content with custom elements. Enable it
+The [Markdown in HTML] extension allows for writing Markdown inside of HTML, which is useful for wrapping Markdown content with custom elements. Enable it
 via `mkdocs.yml`:
 
 ``` yaml
@@ -79,7 +79,7 @@ markdown_extensions:
   - md_in_html
 ```
 
-From the [Markdown in HTML]{target="_blank"} extension's docs:
+From the [Markdown in HTML] extension's docs:
 > By default, Markdown ignores any content within a raw HTML block-level element. With the `md_in_html` extension enabled, the content of a raw HTML block-level element can be parsed as Markdown by including a `markdown` attribute on the opening tag. The `markdown` attribute will be stripped from the output, while all other attributes will be preserved.
 
 
@@ -95,7 +95,7 @@ No configuration options are available. See reference for usage:
 
 ## Table of Contents
 
-The [Table of Contents]{target="_blank"} extension automatically generates a table of contents from a document which Terminal for MkDocs will render as part of the resulting page. It can be configured via `mkdocs.yml`:
+The [Table of Contents] extension automatically generates a table of contents from a document which Terminal for MkDocs will render as part of the resulting page. It can be configured via `mkdocs.yml`:
 
 ``` yaml
 markdown_extensions:
@@ -151,7 +151,7 @@ See reference for usage:
 
 ## Tables
 
-The [Tables]{target="_blank"} extension adds the ability to create tables in Markdown by using a simple syntax. Enable it via `mkdocs.yml` (albeit it should be enabled by
+The [Tables] extension adds the ability to create tables in Markdown by using a simple syntax. Enable it via `mkdocs.yml` (albeit it should be enabled by
 default):
 
 ``` yaml
@@ -170,5 +170,5 @@ No configuration options are available. See reference for usage:
 
 # Credit
 
-This documentation page is based on squidfunk's Material for MkDocs [Python Markdown](https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown/){target="_blank"} documentation.
+This documentation page is based on squidfunk's Material for MkDocs [Python Markdown](https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown/) documentation.
 

--- a/documentation/docs/configuration/extensions/snippets.md
+++ b/documentation/docs/configuration/extensions/snippets.md
@@ -13,7 +13,7 @@ markdown_extensions:
         - docs
 ```
 
-See the [Snippets documentation][Snippets]{target="_blank"} for more information on configuration options.
+See the [Snippets documentation][Snippets] for more information on configuration options.
 
   [Snippets]: https://facelessuser.github.io/pymdown-extensions/extensions/snippets/
   

--- a/documentation/docs/configuration/features.md
+++ b/documentation/docs/configuration/features.md
@@ -47,7 +47,7 @@ enables the "Page last updated..." text at the bottom of the page.  requires [gi
 enables the "See revision history..." text at the bottom of the page.  requires [git-revision-date plugin setup] and additional [git-revision-date configuration].
 
 ## style.links.underline.hide
-hides the underline styling on links.  the underline text decoration on links is added to make the links identifiable without color vision.  if you choose to hide this styling you should consider adding an alternate [non-color link indicator]{target="_blank"}.    
+hides the underline styling on links.  the underline text decoration on links is added to make the links identifiable without color vision.  if you choose to hide this styling you should consider adding an alternate [non-color link indicator].    
 
 [git-revision-date plugin setup]: ../plugins/git-revision/
 [git-revision-date configuration]: ../plugins/git-revision/#advanced-configuration
@@ -56,7 +56,7 @@ hides the underline styling on links.  the underline text decoration on links is
 
 # Page Features
 
-To hide certain [Terminal for MkDocs components] on a per-page basis, add a [YAML Style Meta-Data]{target="_blank"} section to the very top of your Markdown page. Inside this metadata section, add the attribute `hide` which is a list of page-specific feature names.
+To hide certain [Terminal for MkDocs components] on a per-page basis, add a [YAML Style Meta-Data] section to the very top of your Markdown page. Inside this metadata section, add the attribute `hide` which is a list of page-specific feature names.
 
 Pay special attention to the indentation. There should be two spaces before the `-` marking the start of a component name: 
 

--- a/documentation/docs/configuration/plugins/git-revision.md
+++ b/documentation/docs/configuration/plugins/git-revision.md
@@ -1,9 +1,9 @@
 # Git Revision Date Plugin
-The third-party [git-revision-date]{target="_blank"} plugin automatically adds the last revision date of a markdown page to its MkDocs Page Metadata[^mkdocs-page-meta].  
+The third-party [git-revision-date] plugin automatically adds the last revision date of a markdown page to its MkDocs Page Metadata[^mkdocs-page-meta].  
 
 [git-revision-date]: https://github.com/zhaoterryy/mkdocs-git-revision-date-plugin
 [MkDocs Page Metadata]: https://www.mkdocs.org/user-guide/writing-your-docs/#meta-data
-[^mkdocs-page-meta]: see [MkDocs Page Metadata]{target="_blank"} for more info
+[^mkdocs-page-meta]: see [MkDocs Page Metadata] for more info
 
 # Built-in Support
 When the `git-revision-date` plugin is installed and enabled and the `revision.date` theme feature is enabled, Terminal for MkDocs will display the date of the most recent change to a page's source file on the rendered site page.  This component is added at the bottom of each page unless [page-specific hiding] is enabled.
@@ -54,7 +54,7 @@ theme:
 # Advanced Configuration
 There are two revision-related theme features that can be individually enabled.  The example above only discusses `revision.date` as it is easier to configure without error.  
 
-The second revision-related theme feature is `revision.history`.  Enabling this theme feature will add a "See revision history..." note to the bottom of the page.  The link included in this note relies on MkDocs' [repo_url]{target="_blank"}, [repo_name]{target="_blank"}, and [edit_uri]{target="_blank"}/[edit_uri_template]{target="_blank"} settings.  
+The second revision-related theme feature is `revision.history`.  Enabling this theme feature will add a "See revision history..." note to the bottom of the page.  The link included in this note relies on MkDocs' [repo_url], [repo_name], and [edit_uri]/[edit_uri_template] settings.  
 
 [repo_url]: https://www.mkdocs.org/user-guide/configuration/#repo_url
 [repo_name]: https://www.mkdocs.org/user-guide/configuration/#repo_name
@@ -125,7 +125,7 @@ theme:
 
 
 ## Adding Repository Hosts
-If your repository is not stored on GitHub or Bitbucket and you would like to use this feature please [submit a feature request]{target="_blank"} on GitHub.  
+If your repository is not stored on GitHub or Bitbucket and you would like to use this feature please [submit a feature request] on GitHub.  
 
 You can further customize what revision information is included on the page by implementing your own `revision` template block.  See [Blocks] for more information.
 

--- a/documentation/docs/configuration/plugins/macros.md
+++ b/documentation/docs/configuration/plugins/macros.md
@@ -1,6 +1,6 @@
 # MkDocs Macros Plugin
 
-The third-party [macros]{target="_blank"} plugin transforms markdown pages into [jinja2]{target="_blank"} templates.  This allows you to create complex and feature-rich pages using variables, calls to custom functions, and filters.  
+The third-party [macros] plugin transforms markdown pages into [jinja2] templates.  This allows you to create complex and feature-rich pages using variables, calls to custom functions, and filters.  
 
 You can write and publish your own functions to use in your markdown pages.  These functions are called macros.  You can also install macros written by others via pip.  Once a macro has been installed, it must be enabled in your MkDocs config before you can use it.
 
@@ -50,6 +50,6 @@ A table with entries describing the MkDocs configuration for your site should be
 
 ## 4. Configuration
 
-See [MkDocs Macros Plugin]{target="_blank"} documentation for configuration options.
+See [MkDocs Macros Plugin] documentation for configuration options.
 
 [MkDocs Macros Plugin]: https://mkdocs-macros-plugin.readthedocs.io/en/latest/#configuration-of-the-plugin

--- a/documentation/docs/configuration/plugins/search.md
+++ b/documentation/docs/configuration/plugins/search.md
@@ -1,5 +1,5 @@
 # Search Plugin
-MkDocs comes with a built-in and automatically enabled [search plugin]{target="_blank"}.  
+MkDocs comes with a built-in and automatically enabled [search plugin].  
 
 [search plugin]: https://www.mkdocs.org/user-guide/configuration/#search
 

--- a/documentation/docs/elements/examples/links.md
+++ b/documentation/docs/elements/examples/links.md
@@ -2,6 +2,6 @@
 
 [Documentation Home Page](/)
 
-[GitHub Repository](https://github.com/ntno/mkdocs-terminal){target="_blank"}
+[GitHub Repository](https://github.com/ntno/mkdocs-terminal)
 
 <br>

--- a/documentation/docs/elements/examples/table.md
+++ b/documentation/docs/elements/examples/table.md
@@ -2,8 +2,8 @@
 
 | Release | Supported? |
 | :-----: | :---------: |
-| [1.0.0]{target="_blank"} | yes |
-| [0.0.0]{target="_blank"} | no |
+| [1.0.0] | yes |
+| [0.0.0] | no |
 
   [1.0.0]: https://github.com/ntno/mkdocs-terminal/releases/tag/1.0.0
   [0.0.0]: https://github.com/ntno/mkdocs-terminal/releases/tag/0.0.0

--- a/documentation/docs/elements/lists.md
+++ b/documentation/docs/elements/lists.md
@@ -43,7 +43,7 @@ To create an unordered list, add dashes (-), asterisks (*), or plus signs (+) in
 ```
 
 # Credit
-Examples and instructional text in this document were adapted from the [basic syntax markdown guide]{target="_blank"} on [markdownguide.org]{target="_blank"}.
+Examples and instructional text in this document were adapted from the [basic syntax markdown guide] on [markdownguide.org].
 
 [basic syntax markdown guide]: https://www.markdownguide.org/basic-syntax/#lists-1
 [markdownguide.org]: https://www.markdownguide.org

--- a/documentation/docs/elements/table.md
+++ b/documentation/docs/elements/table.md
@@ -35,8 +35,8 @@ Note: this example requires the [attr_list extension] be enabled.
 
 | Release | Supported? |
 | :-----: | :---------: |
-| [1.0.0]{target="_blank"} | yes |
-| [0.0.0]{target="_blank"} | no |
+| [1.0.0] | yes |
+| [0.0.0] | no |
 
   [1.0.0]: https://github.com/ntno/mkdocs-terminal/releases/tag/1.0.0
   [0.0.0]: https://github.com/ntno/mkdocs-terminal/releases/tag/0.0.0
@@ -45,8 +45,8 @@ Note: this example requires the [attr_list extension] be enabled.
 ```markdown
 | Release | Supported? |
 | :-----: | :---------: |
-| [1.0.0]{target="_blank"} | yes |
-| [0.0.0]{target="_blank"} | no |
+| [1.0.0] | yes |
+| [0.0.0] | no |
 
   [1.0.0]: https://github.com/ntno/mkdocs-terminal/releases/tag/1.0.0
   [0.0.0]: https://github.com/ntno/mkdocs-terminal/releases/tag/0.0.0

--- a/documentation/docs/index.md
+++ b/documentation/docs/index.md
@@ -5,7 +5,7 @@ hide:
 ---
 
 # mkdocs-terminal
-Terminal for MkDocs is a third party theme that brings the [Terminal.css](https://github.com/Gioni06/terminal.css){target="_blank"} stylesheet to MkDocs documentation sites.  
+Terminal for MkDocs is a third party theme that brings the [Terminal.css](https://github.com/Gioni06/terminal.css) stylesheet to MkDocs documentation sites.  
 
 In addition to simple, monospace styling, Terminal for MkDocs also provides: 
 
@@ -18,10 +18,10 @@ In addition to simple, monospace styling, Terminal for MkDocs also provides:
 - and more
 
 ## Developer Info
-[Terminal for MkDocs on GitHub](https://github.com/ntno/mkdocs-terminal){target="_blank"}  
-[Terminal for MkDocs on PyPI](https://pypi.org/project/mkdocs-terminal/){target="_blank"}  
-[Terminal for MkDocs Documentation](https://ntno.github.io/mkdocs-terminal/){target="_blank"}  
-[MkDocs Documentation](https://www.mkdocs.org/){target="_blank"}  
+[Terminal for MkDocs on GitHub](https://github.com/ntno/mkdocs-terminal)  
+[Terminal for MkDocs on PyPI](https://pypi.org/project/mkdocs-terminal/)  
+[Terminal for MkDocs Documentation](https://ntno.github.io/mkdocs-terminal/)  
+[MkDocs Documentation](https://www.mkdocs.org/)  
 
 
 ### License

--- a/documentation/docs/install.md
+++ b/documentation/docs/install.md
@@ -1,10 +1,10 @@
 # Installation
 
 ## 1. Setup MkDocs project
-See [Getting Started](https://www.mkdocs.org/getting-started/){target="_blank"} for details.
+See [Getting Started](https://www.mkdocs.org/getting-started/) for details.
 
 ## 2. Install Theme
-Install the [mkdocs-terminal pip package](https://pypi.org/project/mkdocs-terminal/){target="_blank"}.  Add the package to your `requirements.txt` file:
+Install the [mkdocs-terminal pip package](https://pypi.org/project/mkdocs-terminal/).  Add the package to your `requirements.txt` file:
 
 ```text
 mkdocs

--- a/documentation/docs/navigation/toc.md
+++ b/documentation/docs/navigation/toc.md
@@ -1,7 +1,7 @@
 # Table of Contents
 By default, only the top two sections by nesting level will display in the table of contents at the bottom left.  
 
-For fine-grained control of which items display in the table of contents, add `toc` to `markdown_extensions` and configure according to the `toc` package's [extension options](https://python-markdown.github.io/extensions/toc/#usage){target="_blank"}.
+For fine-grained control of which items display in the table of contents, add `toc` to `markdown_extensions` and configure according to the `toc` package's [extension options](https://python-markdown.github.io/extensions/toc/#usage).
 
 **file**: `mkdocs.yml`  
 ```yaml
@@ -42,9 +42,9 @@ Quisque sed posuere erat. Praesent et volutpat orci. Cras vulputate, leo id pret
 
 ### (h3) Felis catus
 Domestic cats:  
-- [Maine Coon](https://en.wikipedia.org/wiki/Maine_Coon){target="_blank"}  
-- [Siberian](https://en.wikipedia.org/wiki/Siberian_cat){target="_blank"}  
-- [Sphynx](https://en.wikipedia.org/wiki/Sphynx_cat){target="_blank"}  
+- [Maine Coon](https://en.wikipedia.org/wiki/Maine_Coon)  
+- [Siberian](https://en.wikipedia.org/wiki/Siberian_cat)  
+- [Sphynx](https://en.wikipedia.org/wiki/Sphynx_cat)  
 
 ## (h2) Pantherinae - (roaring)
 Aliquam turpis purus, mattis et enim nec, euismod varius augue. Duis sit amet pretium justo. Praesent tortor dolor, tempor tempor erat vitae, facilisis blandit urna. Quisque lacinia fermentum ligula, sit amet dapibus mauris laoreet eget. Cras facilisis viverra libero, vel molestie ante posuere eget. 
@@ -63,9 +63,9 @@ Curabitur metus tellus, commodo et faucibus vitae, posuere ut dolor. Vivamus ult
 
 ##### (h5) Canis familiaris
 Domestic dogs:  
-- [Alaskan Husky](https://en.wikipedia.org/wiki/Alaskan_husky){target="_blank"}  
-- [Beagle](https://en.wikipedia.org/wiki/Beagle){target="_blank"}  
-- [Greyhound](https://en.wikipedia.org/wiki/Greyhound){target="_blank"}  
+- [Alaskan Husky](https://en.wikipedia.org/wiki/Alaskan_husky)  
+- [Beagle](https://en.wikipedia.org/wiki/Beagle)  
+- [Greyhound](https://en.wikipedia.org/wiki/Greyhound)  
 
 
 

--- a/documentation/docs/releases.md
+++ b/documentation/docs/releases.md
@@ -1,6 +1,6 @@
 # Versioning
 
-Terminal for MkDocs uses [semantic versioning]{target="_blank"}.  Each version number is in the format `MAJOR.MINOR.PATCH`.  Given a version number `MAJOR.MINOR.PATCH`:
+Terminal for MkDocs uses [semantic versioning].  Each version number is in the format `MAJOR.MINOR.PATCH`.  Given a version number `MAJOR.MINOR.PATCH`:
 
 - the **MAJOR** version increments with an incompatible API change
 - the **MINOR** version increments with added functionality in a backwards compatible manner
@@ -15,7 +15,7 @@ We recommend that you pin your dependency on `mkdocs-terminal` to the latest sup
 
 example: `mkdocs-terminal~=3.0`
 
-See [Version Identification and Dependency Specification]{target="_blank"} for additional constraint examples.
+See [Version Identification and Dependency Specification] for additional constraint examples.
 
 [Version Identification and Dependency Specification]: https://peps.python.org/pep-0440/#examples
 
@@ -24,10 +24,10 @@ See [Version Identification and Dependency Specification]{target="_blank"} for a
 
 |         Release          | Theme Status | Supported? |
 | :----------------------: | :----------: | :--------: |
-| [3.9.0]{target="_blank"} |    Alpha     |     no     |
-| [3.7.0]{target="_blank"} |    Alpha     |     no     |
-| [3.0.0]{target="_blank"} |    Alpha     |     no     |
-| [2.2.0]{target="_blank"} |    Alpha     |     no     |
+| [3.9.0] |    Alpha     |     no     |
+| [3.7.0] |    Alpha     |     no     |
+| [3.0.0] |    Alpha     |     no     |
+| [2.2.0] |    Alpha     |     no     |
 
 
 <br>

--- a/documentation/docs/tile-grid/examples/links-only.md
+++ b/documentation/docs/tile-grid/examples/links-only.md
@@ -12,20 +12,17 @@ tiles:
     link_href: ../example-page
   - caption: "\\#tile_123"
     tile_id: "tile_123"
-    link_target: "_self"
-    link_title: go to overview in this window
+    link_title: go to overview
     link_text: Tile Grid Overview
     link_href: ../..
   - caption: "\\#tile_456"
     tile_id: "tile_456"
-    link_target: "_self"
-    link_title: go to tile reference in this window
+    link_title: go to tile reference
     link_text: Tile Reference
     link_href: ../../tile
   - caption: ".example_highlight"
     tile_css: "example_highlight"
-    link_target: "_self"
-    link_title: go to grid reference in this window
+    link_title: go to grid reference
     link_text: Grid Reference
     link_href: ../../grid
 ---
@@ -68,20 +65,17 @@ tiles:
     link_href: ../example-page
   - caption: "\\#tile_123"
     tile_id: "tile_123"
-    link_target: "_self"
-    link_title: go to overview in this window
+    link_title: go to overview
     link_text: Tile Grid Overview
     link_href: ../..
   - caption: "\\#tile_456"
     tile_id: "tile_456"
-    link_target: "_self"
-    link_title: go to tile reference in this window
+    link_title: go to tile reference
     link_text: Tile Reference
     link_href: ../../tile
   - caption: ".example_highlight"
     tile_css: "example_highlight"
-    link_target: "_self"
-    link_title: go to grid reference in this window
+    link_title: go to grid reference
     link_text: Grid Reference
     link_href: ../../grid
 ---

--- a/documentation/docs/tile-grid/grid.md
+++ b/documentation/docs/tile-grid/grid.md
@@ -40,7 +40,7 @@ tiles:
 
 ## Default Tile Placement
 
-See [Example Page]{target="_blank", title="open default grid example in new tab"}
+See [Example Page]
 
 ### Markdown
 ```markdown
@@ -52,7 +52,7 @@ tile-grid/examples/example-page.md
 
 ## Tiles First
 
-See [Tiles First example]{target="_blank", title="open tiles first example in new tab"}
+See [Tiles First example]
 
 ### Markdown
 ```markdown

--- a/documentation/docs/tile-grid/index.md
+++ b/documentation/docs/tile-grid/index.md
@@ -15,7 +15,7 @@ Terminal for MkDocs enables you to quickly create a grid of linked tiles.  Each 
 To use this feature, complete the following steps:
 
 ## 1. Add `tiles` to Page Metadata
-Add a [YAML Style Meta-Data]{target="_blank"} section to the very top of your Markdown page.  The metadata should contain the attribute `tiles` which is a list of YAML objects.  
+Add a [YAML Style Meta-Data] section to the very top of your Markdown page.  The metadata should contain the attribute `tiles` which is a list of YAML objects.  
 
 Pay special attention to the indentation.  There should be two spaces before the `-` marking the start of an object.  There should be four spaces before any additional object attribute:  
 
@@ -50,8 +50,8 @@ nav:
         - Also Works: 'tile-grid/examples/example-page.md'
 ```
 
-[^mkdocs-page-object]: [MkDocs Page Object]{target="_blank"}
-[^mkdocs-page-meta]: [MkDocs Page Metadata]{target="_blank"}
+[^mkdocs-page-object]: [MkDocs Page Object]
+[^mkdocs-page-meta]: [MkDocs Page Metadata]
 
 [YAML Style Meta-Data]: https://www.mkdocs.org/user-guide/writing-your-docs/#yaml-style-meta-data
 [MkDocs Page Object]: https://www.mkdocs.org/dev-guide/themes/#navigation-objects

--- a/notes/untested-py-mdown.md
+++ b/notes/untested-py-mdown.md
@@ -1,4 +1,4 @@
-In general, all extensions that are part of [PyMdown Extensions]{target="_blank"} should work with Material for MkDocs. The following list includes all extensions that
+In general, all extensions that are part of [PyMdown Extensions] should work with Material for MkDocs. The following list includes all extensions that
 are natively supported, meaning they work without any further adjustments.
 
 ### Arithmatex
@@ -219,7 +219,7 @@ markdown_extensions:
       emoji_generator: !!python/name:materialx.emoji.to_svg
 ```
 
-1.  [PyMdown Extensions]{target="_blank"} uses the `pymdownx` namespace, but in order to
+1.  [PyMdown Extensions] uses the `pymdownx` namespace, but in order to
     support the inlining of icons, the `materialx` namespace must be used, as it
     extends the functionality of `pymdownx`.
 
@@ -649,7 +649,7 @@ The following configuration options are supported:
 :   :octicons-milestone-24: Default: `headerid.slugify` – This option allows for
     customization of the slug function. For some languages, the default may not
     produce good and readable identifiers – consider using another slug function
-    like for example those from [PyMdown Extensions]{target="_blank"}[Slugs]:
+    like for example those from [PyMdown Extensions][Slugs]:
 
     === "Unicode"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "mkdocs-terminal",
-    "version": "3.10.1",
+    "version": "3.10.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mkdocs-terminal",
-    "version": "3.10.1",
+    "version": "3.10.2",
     "description": "Terminal.css theme for MkDocs",
     "keywords": [
         "mkdocs",

--- a/terminal/partials/footer.html
+++ b/terminal/partials/footer.html
@@ -2,6 +2,6 @@
     <div class="container">
         {% if config.copyright %}
         <p class="text-center text-muted">{{ config.copyright }}</p>
-        {% endif %} Site built with <a target="_blank" href="http://www.mkdocs.org">MkDocs</a> and <a target="_blank" href="https://github.com/ntno/mkdocs-terminal">Terminal for MkDocs</a>.
+        {% endif %} Site built with <a href="http://www.mkdocs.org">MkDocs</a> and <a href="https://github.com/ntno/mkdocs-terminal">Terminal for MkDocs</a>.
     </div>
 </footer>

--- a/terminal/partials/page-content/revision.html
+++ b/terminal/partials/page-content/revision.html
@@ -26,10 +26,10 @@
             {%- if show_date -%}Page last updated {{ page.meta.revision_date }}. {% endif %}
             {%- if show_history -%}
             {%- if config.repo_name == "GitHub" -%}
-            See revision history on <a target="_blank" href="{{ page.edit_url | replace('/edit/','/commits/') }}">{{ config.repo_name }}</a>.
+            See revision history on <a href="{{ page.edit_url | replace('/edit/','/commits/') }}">{{ config.repo_name }}</a>.
             {%- endif -%}
             {%- if config.repo_name == "Bitbucket" -%}
-            See revision history on <a target="_blank" href="{{ page.edit_url | replace('mode=edit','mode=read') }}">{{ config.repo_name }}</a>.
+            See revision history on <a href="{{ page.edit_url | replace('mode=edit','mode=read') }}">{{ config.repo_name }}</a>.
             {%- endif -%}
             {%- endif -%}
             </i>

--- a/terminal/theme_version.html
+++ b/terminal/theme_version.html
@@ -1,1 +1,1 @@
-<meta name="generator" content="mkdocs-{{ mkdocs_version }}, mkdocs-terminal-3.10.1">
+<meta name="generator" content="mkdocs-{{ mkdocs_version }}, mkdocs-terminal-3.10.2">

--- a/tests/test_revision.py
+++ b/tests/test_revision.py
@@ -124,7 +124,7 @@ class TestRevision():
         context_data = enabled_context
         rendered_revision = revision_partial.render(context_data)
         assert "Page last updated 2022/05/06. See revision history on" in rendered_revision
-        assert "<a target=\"_blank\" href=\"" + expected_page_history_url + "\">GitHub</a>" in rendered_revision
+        assert "<a href=\"" + expected_page_history_url + "\">GitHub</a>" in rendered_revision
         assert_valid_html(rendered_revision)
 
     def test_bitbucket_history_link(self, revision_partial, enabled_context):
@@ -135,7 +135,7 @@ class TestRevision():
         context_data = enabled_context
         rendered_revision = revision_partial.render(context_data)
         assert "Page last updated 2023/03/04. See revision history on" in rendered_revision
-        assert "<a target=\"_blank\" href=\"" + expected_page_source_url + "\">Bitbucket</a>" in rendered_revision
+        assert "<a href=\"" + expected_page_source_url + "\">Bitbucket</a>" in rendered_revision
         assert_valid_html(rendered_revision)
 
     def test_last_updated_text_hidden_when_date_disabled_on_page(self, revision_partial, enabled_context):


### PR DESCRIPTION
#115 - do not force new window/tab on link click


### Description
- removes use of target="_blank" in documentation site
- remove use of target="_blank" in theme footer and revision block

### References

- https://yale.app.box.com/s/ochc2c7zzhsj4wuk6fv41hbk5w8vhxt5
- https://css-tricks.com/use-target_blank/
- https://adrianroselli.com/2020/02/link-targets-and-3-2-5.html

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in [mkdocs-terminal/documentation](https://github.com/ntno/mkdocs-terminal/tree/main/documentation/docs)
- [x] All active GitHub checks for tests, formatting, and security are passing

