### PR TITLE
fix link hover style issue in tile grid

### DIFF
--- a/documentation/docs/about/coverage-report/index.html
+++ b/documentation/docs/about/coverage-report/index.html
@@ -47,7 +47,7 @@
         </form>
         <p class="text">
             <a class="nav" href="https://coverage.readthedocs.io">coverage.py v7.1.0</a>,
-            created at 2023-01-30 04:48 +0000
+            created at 2023-01-31 04:48 +0000
         </p>
     </div>
 </header>
@@ -158,7 +158,7 @@
     <div class="content">
         <p>
             <a class="nav" href="https://coverage.readthedocs.io">coverage.py v7.1.0</a>,
-            created at 2023-01-30 04:48 +0000
+            created at 2023-01-31 04:48 +0000
         </p>
     </div>
     <aside class="hidden">

--- a/documentation/docs/configuration/palettes/dark.md
+++ b/documentation/docs/configuration/palettes/dark.md
@@ -1,3 +1,23 @@
+---
+show_tiles_inline: true
+tiles:
+  - caption: '@petradr'
+    img_src: ../../../img/picsum/167_200x200.jpeg
+    img_title: 'to Picsum homepage'
+    img_alt: 'close up of fallen leaves.'
+    link_href: https://picsum.photos/ 
+  - caption: 'Marcin Czerwinski'
+    img_src: ../../../img/picsum/127_200x200.jpeg
+    img_title: 'to Picsum homepage'
+    img_alt: 'close up of green moss on a log.'
+    link_href: https://picsum.photos/ 
+  - caption: "Steve Richey"
+    img_src: ../../../img/picsum/143_200x200.jpeg
+    img_title: 'to Picsum homepage'
+    img_alt: 'overhead of fallen leaves.'
+    link_href: https://picsum.photos/
+---
+
 --8<--
 configuration/palettes/links.md
 --8<--
@@ -17,3 +37,8 @@ theme:
 --8<--
 elements/examples/index.md
 --8<--
+
+## Tile Grid Example
+{{ tile_grid(page.meta) }}
+
+<br>

--- a/documentation/docs/configuration/palettes/default.md
+++ b/documentation/docs/configuration/palettes/default.md
@@ -1,3 +1,23 @@
+---
+show_tiles_inline: true
+tiles:
+  - caption: '@petradr'
+    img_src: ../../../img/picsum/167_200x200.jpeg
+    img_title: 'to Picsum homepage'
+    img_alt: 'close up of fallen leaves.'
+    link_href: https://picsum.photos/ 
+  - caption: 'Marcin Czerwinski'
+    img_src: ../../../img/picsum/127_200x200.jpeg
+    img_title: 'to Picsum homepage'
+    img_alt: 'close up of green moss on a log.'
+    link_href: https://picsum.photos/ 
+  - caption: "Steve Richey"
+    img_src: ../../../img/picsum/143_200x200.jpeg
+    img_title: 'to Picsum homepage'
+    img_alt: 'overhead of fallen leaves.'
+    link_href: https://picsum.photos/
+---
+
 --8<--
 configuration/palettes/links.md
 --8<--
@@ -15,3 +35,8 @@ theme:
 --8<--
 elements/examples/index.md
 --8<--
+
+## Tile Grid Example
+{{ tile_grid(page.meta) }}
+
+<br>

--- a/documentation/docs/configuration/palettes/gruvbox-dark.md
+++ b/documentation/docs/configuration/palettes/gruvbox-dark.md
@@ -1,3 +1,23 @@
+---
+show_tiles_inline: true
+tiles:
+  - caption: '@petradr'
+    img_src: ../../../img/picsum/167_200x200.jpeg
+    img_title: 'to Picsum homepage'
+    img_alt: 'close up of fallen leaves.'
+    link_href: https://picsum.photos/ 
+  - caption: 'Marcin Czerwinski'
+    img_src: ../../../img/picsum/127_200x200.jpeg
+    img_title: 'to Picsum homepage'
+    img_alt: 'close up of green moss on a log.'
+    link_href: https://picsum.photos/ 
+  - caption: "Steve Richey"
+    img_src: ../../../img/picsum/143_200x200.jpeg
+    img_title: 'to Picsum homepage'
+    img_alt: 'overhead of fallen leaves.'
+    link_href: https://picsum.photos/
+---
+
 --8<--
 configuration/palettes/links.md
 --8<--
@@ -17,3 +37,8 @@ theme:
 --8<--
 elements/examples/index.md
 --8<--
+
+## Tile Grid Example
+{{ tile_grid(page.meta) }}
+
+<br>

--- a/documentation/docs/configuration/palettes/pink.md
+++ b/documentation/docs/configuration/palettes/pink.md
@@ -1,3 +1,23 @@
+---
+show_tiles_inline: true
+tiles:
+  - caption: '@petradr'
+    img_src: ../../../img/picsum/167_200x200.jpeg
+    img_title: 'to Picsum homepage'
+    img_alt: 'close up of fallen leaves.'
+    link_href: https://picsum.photos/ 
+  - caption: 'Marcin Czerwinski'
+    img_src: ../../../img/picsum/127_200x200.jpeg
+    img_title: 'to Picsum homepage'
+    img_alt: 'close up of green moss on a log.'
+    link_href: https://picsum.photos/ 
+  - caption: "Steve Richey"
+    img_src: ../../../img/picsum/143_200x200.jpeg
+    img_title: 'to Picsum homepage'
+    img_alt: 'overhead of fallen leaves.'
+    link_href: https://picsum.photos/
+---
+
 --8<--
 configuration/palettes/links.md
 --8<--
@@ -17,3 +37,8 @@ theme:
 --8<--
 elements/examples/index.md
 --8<--
+
+## Tile Grid Example
+{{ tile_grid(page.meta) }}
+
+<br>

--- a/documentation/docs/configuration/palettes/sans-dark.md
+++ b/documentation/docs/configuration/palettes/sans-dark.md
@@ -1,3 +1,23 @@
+---
+show_tiles_inline: true
+tiles:
+  - caption: '@petradr'
+    img_src: ../../../img/picsum/167_200x200.jpeg
+    img_title: 'to Picsum homepage'
+    img_alt: 'close up of fallen leaves.'
+    link_href: https://picsum.photos/ 
+  - caption: 'Marcin Czerwinski'
+    img_src: ../../../img/picsum/127_200x200.jpeg
+    img_title: 'to Picsum homepage'
+    img_alt: 'close up of green moss on a log.'
+    link_href: https://picsum.photos/ 
+  - caption: "Steve Richey"
+    img_src: ../../../img/picsum/143_200x200.jpeg
+    img_title: 'to Picsum homepage'
+    img_alt: 'overhead of fallen leaves.'
+    link_href: https://picsum.photos/
+---
+
 --8<--
 configuration/palettes/links.md
 --8<--
@@ -17,3 +37,8 @@ theme:
 --8<--
 elements/examples/index.md
 --8<--
+
+## Tile Grid Example
+{{ tile_grid(page.meta) }}
+
+<br>

--- a/documentation/docs/configuration/palettes/sans.md
+++ b/documentation/docs/configuration/palettes/sans.md
@@ -1,3 +1,23 @@
+---
+show_tiles_inline: true
+tiles:
+  - caption: '@petradr'
+    img_src: ../../../img/picsum/167_200x200.jpeg
+    img_title: 'to Picsum homepage'
+    img_alt: 'close up of fallen leaves.'
+    link_href: https://picsum.photos/ 
+  - caption: 'Marcin Czerwinski'
+    img_src: ../../../img/picsum/127_200x200.jpeg
+    img_title: 'to Picsum homepage'
+    img_alt: 'close up of green moss on a log.'
+    link_href: https://picsum.photos/ 
+  - caption: "Steve Richey"
+    img_src: ../../../img/picsum/143_200x200.jpeg
+    img_title: 'to Picsum homepage'
+    img_alt: 'overhead of fallen leaves.'
+    link_href: https://picsum.photos/
+---
+
 --8<--
 configuration/palettes/links.md
 --8<--
@@ -17,3 +37,8 @@ theme:
 --8<--
 elements/examples/index.md
 --8<--
+
+## Tile Grid Example
+{{ tile_grid(page.meta) }}
+
+<br>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "mkdocs-terminal",
-    "version": "3.10.2",
+    "version": "3.11.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mkdocs-terminal",
-    "version": "3.10.2",
+    "version": "3.11.0",
     "description": "Terminal.css theme for MkDocs",
     "keywords": [
         "mkdocs",

--- a/terminal/css/theme.css
+++ b/terminal/css/theme.css
@@ -16,7 +16,8 @@ a.btn {
     text-decoration: none !important;
 }
 
-.terminal-mkdocs-tile-link a:hover {
+/* if linked tile, highlight the link container on hover */
+.terminal-mkdocs-tile-link:has(a:hover) {
     color: var(--primary-color) !important;
 }
 

--- a/terminal/css/theme.css
+++ b/terminal/css/theme.css
@@ -16,6 +16,10 @@ a.btn {
     text-decoration: none !important;
 }
 
+.terminal-mkdocs-tile-link a:hover {
+    color: var(--primary-color) !important;
+}
+
 .terminal-mkdocs-main-grid {
     display: grid;
     grid-column-gap: 1.4em;

--- a/terminal/css/theme.css
+++ b/terminal/css/theme.css
@@ -16,11 +16,6 @@ a.btn {
     text-decoration: none !important;
 }
 
-/* if linked tile, highlight the link container on hover */
-/* .terminal-mkdocs-tile-link:has(a:hover) {
-    color: var(--primary-color) !important;
-} */
-
 .terminal-mkdocs-main-grid {
     display: grid;
     grid-column-gap: 1.4em;

--- a/terminal/css/theme.css
+++ b/terminal/css/theme.css
@@ -17,9 +17,9 @@ a.btn {
 }
 
 /* if linked tile, highlight the link container on hover */
-.terminal-mkdocs-tile-link:has(a:hover) {
+/* .terminal-mkdocs-tile-link:has(a:hover) {
     color: var(--primary-color) !important;
-}
+} */
 
 .terminal-mkdocs-main-grid {
     display: grid;

--- a/terminal/pluglets/tile_grid/templates/j2-macros/tile-link.j2
+++ b/terminal/pluglets/tile_grid/templates/j2-macros/tile-link.j2
@@ -1,5 +1,5 @@
 {% macro make_link_start( tile ) -%}
-<a  href="{{ tile.link_href }}" 
+<div class="terminal-mkdocs-tile-link"><a href="{{ tile.link_href }}" 
     {%- if tile.link_title is defined and tile.link_title|string|length %} title="{{ tile.link_title }}"{% endif %} 
     {%- if tile.link_target is defined and tile.link_target|string|length %} target="{{ tile.link_target }}"{% endif %} >
 {%- endmacro -%}

--- a/terminal/pluglets/tile_grid/templates/j2-macros/tile.j2
+++ b/terminal/pluglets/tile_grid/templates/j2-macros/tile.j2
@@ -24,7 +24,7 @@
             {%- endif -%}
             {%- if ns.has_link -%}
                 {% if ns.has_image %} 
-            </a>{% else %}{{ tile.link_text|default(tile.link_href, true) }}</a>{%- endif %}
+            </a></div>{% else %}{{ tile.link_text|default(tile.link_href, true) }}</a>{%- endif %}
             {%- endif -%}
             {%- if ns.has_caption -%}
                 {%- if use_markup %}

--- a/terminal/pluglets/tile_grid/templates/j2-macros/tile.j2
+++ b/terminal/pluglets/tile_grid/templates/j2-macros/tile.j2
@@ -24,7 +24,7 @@
             {%- endif -%}
             {%- if ns.has_link -%}
                 {% if ns.has_image %} 
-            </a></div>{% else %}{{ tile.link_text|default(tile.link_href, true) }}</a>{%- endif %}
+            </a></div>{% else %}{{ tile.link_text|default(tile.link_href, true) }}</a></div>{%- endif %}
             {%- endif -%}
             {%- if ns.has_caption -%}
                 {%- if use_markup %}

--- a/terminal/theme_version.html
+++ b/terminal/theme_version.html
@@ -1,1 +1,1 @@
-<meta name="generator" content="mkdocs-{{ mkdocs_version }}, mkdocs-terminal-3.10.2">
+<meta name="generator" content="mkdocs-{{ mkdocs_version }}, mkdocs-terminal-3.11.0">

--- a/tests/interface/theme_pluglets.py
+++ b/tests/interface/theme_pluglets.py
@@ -1,3 +1,3 @@
 TILE_GRID_MACRO_USAGE_MESSAGE = "<p class=\"terminal-mkdocs-macro-error-banner\"><strong>USAGE:</strong>&nbsp;&nbsp;<code>{{ tile_grid(page.meta) }}</code></p>"
 TILE_GRID_MACRO_SECTION_START_TAG = "<section id=\"terminal-mkdocs-tile-grid-macro-output\">"
-TILE_LINK_START_TAG = "<div class=\"terminal-mkdocs-tile-link\"><a>"
+TILE_LINK_START_TAG = "<div class=\"terminal-mkdocs-tile-link\"><a "

--- a/tests/interface/theme_pluglets.py
+++ b/tests/interface/theme_pluglets.py
@@ -1,2 +1,3 @@
 TILE_GRID_MACRO_USAGE_MESSAGE = "<p class=\"terminal-mkdocs-macro-error-banner\"><strong>USAGE:</strong>&nbsp;&nbsp;<code>{{ tile_grid(page.meta) }}</code></p>"
 TILE_GRID_MACRO_SECTION_START_TAG = "<section id=\"terminal-mkdocs-tile-grid-macro-output\">"
+TILE_LINK_START_TAG = "<div class=\"terminal-mkdocs-tile-link\"><a>"

--- a/tests/tile_grid/test_tile_link_start.py
+++ b/tests/tile_grid/test_tile_link_start.py
@@ -1,4 +1,5 @@
 from tests import defaults
+from tests.interface import theme_pluglets
 import pytest
 
 
@@ -12,6 +13,7 @@ class TestTileLinkHelper():
     def test_that_link_start_contains_href_with_minimal_link_only_tile(self, tile_link_macro, minimal_link_tile):
         rendered_link_start = tile_link_macro.module.make_link_start(minimal_link_tile)
         assert defaults.GITHUB_LINK_HREF in rendered_link_start
+        assert theme_pluglets.TILE_LINK_START_TAG in rendered_link_start
 
     def test_that_link_start_fragment_renders_with_integer_inputs(self, tile_link_macro, all_integer_tile):
         try:


### PR DESCRIPTION
when a linked tile is hovered we should highlight it just like links are highlighted when links are hovered on.  
we should NOT highlight the figcaption as it could contain a different link from the tile link

### Description

#### linked image tile on hover
![linked-image-tile](https://user-images.githubusercontent.com/20992605/215670426-cafff861-7418-4b34-9a43-aaa2fd411069.png)
#### linked image tile on hover when image is broken
![linked-tile-with-broken-image](https://user-images.githubusercontent.com/20992605/215670428-c39dc38a-1d2c-4b93-9914-006fa6d17e5c.png)
#### linked image tile when image is valid but slow to load
![slow-to-load-image](https://user-images.githubusercontent.com/20992605/215670425-21a39f25-42f5-47fd-8f80-97f85aba9604.png)

### Testing

added examples on palette pages to test contrast in alternate palettes
updated existing unit tests

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in [mkdocs-terminal/documentation](https://github.com/ntno/mkdocs-terminal/tree/main/documentation/docs)
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] ran tox locally
