### PR TITLE
investigate possible solutions for accessibility issues with linked image tile

### DIFF
--- a/documentation/docs/configuration/palettes/index.md
+++ b/documentation/docs/configuration/palettes/index.md
@@ -1,33 +1,33 @@
 ---
 show_tiles_first: true
 tiles:
-  - caption: Default. <br>[fig. details](#default)
+  - caption: Default <sub id="fnref:1"><a class="footnote-ref" alt="to long image description" href="#fn:1">1</a></sub>
     img_src: ../../img/palettes/default.png
     img_alt: Default Demo Page
     link_href: ./default/
-  - caption: Gruvbox Dark
+  - caption: Gruvbox Dark <sub id="fnref:2"><a class="footnote-ref" alt="to long image description" href="#fn:2">2</a></sub>
     img_src: ../../img/palettes/gruvbox_dark.png
     img_alt: Gruvbox Dark Demo Page
     link_href: ./gruvbox-dark/
-  - caption: Dark
+  - caption: Dark <sub id="fnref:3"><a class="footnote-ref" alt="to long image description" href="#fn:3">3</a></sub>
     img_src: ../../img/palettes/dark.png
     img_alt: Dark Demo Page
     link_href: ./dark/    
-  - caption: Pink
+  - caption: Pink <sub id="fnref:4"><a class="footnote-ref" alt="to long image description" href="#fn:4">4</a></sub>
     img_src: ../../img/palettes/pink.png
     img_alt: Pink Demo Page
     link_href: ./pink/        
-  - caption: Sans
+  - caption: Sans <sub id="fnref:5"><a class="footnote-ref" alt="to long image description" href="#fn:5">5</a></sub>
     img_src: ../../img/palettes/sans.png
     img_alt: Sans Demo Page
     link_href: ./sans/    
-  - caption: Sans Dark
+  - caption: Sans Dark <sub id="fnref:6"><a class="footnote-ref" alt="to long image description" href="#fn:6">6</a></sub>
     img_src: ../../img/palettes/sans_dark.png
     img_alt: Sans Dark Demo Page
     link_href: ./sans-dark/            
 ---
 # Theme Color Palettes
-Terminal for MkDocs supports the following color palettes by default:
+Terminal for MkDocs subports the following color palettes by default:
 
   - [default](default.md)
   - [gruvbox_dark](gruvbox-dark.md)
@@ -44,12 +44,9 @@ theme:
   palette: pink
 ```
 
-##### Image Descriptions
-###### Default
-demo site with a white background and light blue hyperlinks.
-
-  <!-- img_desc: 'demo site with a dark grey background, orange hyperlinks, and light yellow text.'
-  img_desc: 'demo site with a black background, light blue hyperlinks, and white text.'
-  img_desc: 'demo site with a white background and pink hyperlinks.'
-  img_desc: 'demo site with a white background, light blue hyperlinks, and sans font.'
-  img_desc: 'demo site with a black background, light blue hyperlinks, and white text in sans font.' -->
+[^1]: demo site with a white background and light blue hyperlinks.
+[^2]: demo site with a dark grey background, orange hyperlinks, and light yellow text.
+[^3]: demo site with a black background, light blue hyperlinks, and white text.
+[^4]: demo site with a white background and pink hyperlinks.
+[^5]: demo site with a white background, light blue hyperlinks, and sans font.
+[^6]: demo site with a black background, light blue hyperlinks, and white text in sans font.

--- a/documentation/docs/configuration/palettes/index.md
+++ b/documentation/docs/configuration/palettes/index.md
@@ -1,35 +1,29 @@
 ---
 show_tiles_first: true
 tiles:
-  - caption: Default
+  - caption: Default. <br>[fig. details](#default)
     img_src: ../../img/palettes/default.png
     img_alt: Default Demo Page
-    img_desc: 'demo site with a white background and light blue hyperlinks.'
     link_href: ./default/
   - caption: Gruvbox Dark
     img_src: ../../img/palettes/gruvbox_dark.png
     img_alt: Gruvbox Dark Demo Page
-    img_desc: 'demo site with a dark grey background, orange hyperlinks, and light yellow text.'
     link_href: ./gruvbox-dark/
   - caption: Dark
     img_src: ../../img/palettes/dark.png
     img_alt: Dark Demo Page
-    img_desc: 'demo site with a black background, light blue hyperlinks, and white text.'
     link_href: ./dark/    
   - caption: Pink
     img_src: ../../img/palettes/pink.png
     img_alt: Pink Demo Page
-    img_desc: 'demo site with a white background and pink hyperlinks.'
     link_href: ./pink/        
   - caption: Sans
     img_src: ../../img/palettes/sans.png
     img_alt: Sans Demo Page
-    img_desc: 'demo site with a white background, light blue hyperlinks, and sans font.'
     link_href: ./sans/    
   - caption: Sans Dark
     img_src: ../../img/palettes/sans_dark.png
     img_alt: Sans Dark Demo Page
-    img_desc: 'demo site with a black background, light blue hyperlinks, and white text in sans font.'
     link_href: ./sans-dark/            
 ---
 # Theme Color Palettes
@@ -50,3 +44,12 @@ theme:
   palette: pink
 ```
 
+##### Image Descriptions
+###### Default
+demo site with a white background and light blue hyperlinks.
+
+  <!-- img_desc: 'demo site with a dark grey background, orange hyperlinks, and light yellow text.'
+  img_desc: 'demo site with a black background, light blue hyperlinks, and white text.'
+  img_desc: 'demo site with a white background and pink hyperlinks.'
+  img_desc: 'demo site with a white background, light blue hyperlinks, and sans font.'
+  img_desc: 'demo site with a black background, light blue hyperlinks, and white text in sans font.' -->

--- a/documentation/docs/configuration/palettes/index.md
+++ b/documentation/docs/configuration/palettes/index.md
@@ -1,27 +1,27 @@
 ---
 show_tiles_first: true
 tiles:
-  - caption: Default <sub id="fnref:1"><a class="footnote-ref" alt="to long image description" href="#fn:1">1</a></sub>
+  - caption: Default <a id="fnref:1" class="footnote-ref" alt="to long image description" href="#fn:1">1</a>
     img_src: ../../img/palettes/default.png
     img_alt: Default Demo Page
     link_href: ./default/
-  - caption: Gruvbox Dark <sub id="fnref:2"><a class="footnote-ref" alt="to long image description" href="#fn:2">2</a></sub>
+  - caption: Gruvbox Dark <a id="fnref:2" class="footnote-ref" alt="to long image description" href="#fn:2">2</a>
     img_src: ../../img/palettes/gruvbox_dark.png
     img_alt: Gruvbox Dark Demo Page
     link_href: ./gruvbox-dark/
-  - caption: Dark <sub id="fnref:3"><a class="footnote-ref" alt="to long image description" href="#fn:3">3</a></sub>
+  - caption: Dark <a id="fnref:3" class="footnote-ref" alt="to long image description" href="#fn:3">3</a>
     img_src: ../../img/palettes/dark.png
     img_alt: Dark Demo Page
     link_href: ./dark/    
-  - caption: Pink <sub id="fnref:4"><a class="footnote-ref" alt="to long image description" href="#fn:4">4</a></sub>
+  - caption: Pink <a id="fnref:4" class="footnote-ref" alt="to long image description" href="#fn:4">4</a>
     img_src: ../../img/palettes/pink.png
     img_alt: Pink Demo Page
     link_href: ./pink/        
-  - caption: Sans <sub id="fnref:5"><a class="footnote-ref" alt="to long image description" href="#fn:5">5</a></sub>
+  - caption: Sans <a id="fnref:5" class="footnote-ref" alt="to long image description" href="#fn:5">5</a>
     img_src: ../../img/palettes/sans.png
     img_alt: Sans Demo Page
     link_href: ./sans/    
-  - caption: Sans Dark <sub id="fnref:6"><a class="footnote-ref" alt="to long image description" href="#fn:6">6</a></sub>
+  - caption: Sans Dark <a id="fnref:6" class="footnote-ref" alt="to long image description" href="#fn:6">6</a>
     img_src: ../../img/palettes/sans_dark.png
     img_alt: Sans Dark Demo Page
     link_href: ./sans-dark/            

--- a/documentation/docs/configuration/palettes/index.md
+++ b/documentation/docs/configuration/palettes/index.md
@@ -1,27 +1,27 @@
 ---
 show_tiles_first: true
 tiles:
-  - caption: <a id="fnref:1" class="footnote-ref" alt="to long image description" href="#fn:1">Default</a>
+  - caption: <a id="fnref:1" class="footnote-ref" title="to image description" alt="to long image description" href="#fn:1">Default</a>
     img_src: ../../img/palettes/default.png
     img_alt: Default Demo Page
     link_href: ./default/
-  - caption: <a id="fnref:2" class="footnote-ref" alt="to long image description" href="#fn:2">Gruvbox Dark</a>
+  - caption: <a id="fnref:2" class="footnote-ref" title="to image description" alt="to long image description" href="#fn:2">Gruvbox Dark</a>
     img_src: ../../img/palettes/gruvbox_dark.png
     img_alt: Gruvbox Dark Demo Page
     link_href: ./gruvbox-dark/
-  - caption: <a id="fnref:3" class="footnote-ref" alt="to long image description" href="#fn:3">Dark</a>
+  - caption: <a id="fnref:3" class="footnote-ref" title="to image description" alt="to long image description" href="#fn:3">Dark</a>
     img_src: ../../img/palettes/dark.png
     img_alt: Dark Demo Page
     link_href: ./dark/    
-  - caption: <a id="fnref:4" class="footnote-ref" alt="to long image description" href="#fn:4">Pink</a>
+  - caption: <a id="fnref:4" class="footnote-ref" title="to image description" alt="to long image description" href="#fn:4">Pink</a>
     img_src: ../../img/palettes/pink.png
     img_alt: Pink Demo Page
     link_href: ./pink/        
-  - caption: <a id="fnref:5" class="footnote-ref" alt="to long image description" href="#fn:5">Sans</a>
+  - caption: <a id="fnref:5" class="footnote-ref" title="to image description" alt="to long image description" href="#fn:5">Sans</a>
     img_src: ../../img/palettes/sans.png
     img_alt: Sans Demo Page
     link_href: ./sans/    
-  - caption: <a id="fnref:6" class="footnote-ref" alt="to long image description" href="#fn:6">Sans Dark</a>
+  - caption: <a id="fnref:6" class="footnote-ref" title="to image description" alt="to long image description" href="#fn:6">Sans Dark</a>
     img_src: ../../img/palettes/sans_dark.png
     img_alt: Sans Dark Demo Page
     link_href: ./sans-dark/            

--- a/documentation/docs/configuration/palettes/index.md
+++ b/documentation/docs/configuration/palettes/index.md
@@ -1,27 +1,27 @@
 ---
 show_tiles_first: true
 tiles:
-  - caption: Default <a id="fnref:1" class="footnote-ref" alt="to long image description" href="#fn:1">1</a>
+  - caption: <a id="fnref:1" class="footnote-ref" alt="to long image description" href="#fn:1">Default</a>
     img_src: ../../img/palettes/default.png
     img_alt: Default Demo Page
     link_href: ./default/
-  - caption: Gruvbox Dark <a id="fnref:2" class="footnote-ref" alt="to long image description" href="#fn:2">2</a>
+  - caption: <a id="fnref:2" class="footnote-ref" alt="to long image description" href="#fn:2">Gruvbox Dark</a>
     img_src: ../../img/palettes/gruvbox_dark.png
     img_alt: Gruvbox Dark Demo Page
     link_href: ./gruvbox-dark/
-  - caption: Dark <a id="fnref:3" class="footnote-ref" alt="to long image description" href="#fn:3">3</a>
+  - caption: <a id="fnref:3" class="footnote-ref" alt="to long image description" href="#fn:3">Dark</a>
     img_src: ../../img/palettes/dark.png
     img_alt: Dark Demo Page
     link_href: ./dark/    
-  - caption: Pink <a id="fnref:4" class="footnote-ref" alt="to long image description" href="#fn:4">4</a>
+  - caption: <a id="fnref:4" class="footnote-ref" alt="to long image description" href="#fn:4">Pink</a>
     img_src: ../../img/palettes/pink.png
     img_alt: Pink Demo Page
     link_href: ./pink/        
-  - caption: Sans <a id="fnref:5" class="footnote-ref" alt="to long image description" href="#fn:5">5</a>
+  - caption: <a id="fnref:5" class="footnote-ref" alt="to long image description" href="#fn:5">Sans</a>
     img_src: ../../img/palettes/sans.png
     img_alt: Sans Demo Page
     link_href: ./sans/    
-  - caption: Sans Dark <a id="fnref:6" class="footnote-ref" alt="to long image description" href="#fn:6">6</a>
+  - caption: <a id="fnref:6" class="footnote-ref" alt="to long image description" href="#fn:6">Sans Dark</a>
     img_src: ../../img/palettes/sans_dark.png
     img_alt: Sans Dark Demo Page
     link_href: ./sans-dark/            

--- a/documentation/docs/configuration/palettes/index.md
+++ b/documentation/docs/configuration/palettes/index.md
@@ -3,27 +3,33 @@ show_tiles_first: true
 tiles:
   - caption: <a id="fnref:1" class="footnote-ref" title="to image description" alt="to long image description" href="#fn:1">Default</a>
     img_src: ../../img/palettes/default.png
+    img_title: to Default Demo Page 
     img_alt: Default Demo Page
     link_href: ./default/
     tile_css: img_link
   - caption: <a id="fnref:2" class="footnote-ref" title="to image description" alt="to long image description" href="#fn:2">Gruvbox Dark</a>
     img_src: ../../img/palettes/gruvbox_dark.png
+    img_title: to Gruvbox Dark Demo Page
     img_alt: Gruvbox Dark Demo Page
     link_href: ./gruvbox-dark/
   - caption: <a id="fnref:3" class="footnote-ref" title="to image description" alt="to long image description" href="#fn:3">Dark</a>
     img_src: ../../img/palettes/dark.png
+    img_title: to Dark Demo Page 
     img_alt: Dark Demo Page
     link_href: ./dark/    
   - caption: <a id="fnref:4" class="footnote-ref" title="to image description" alt="to long image description" href="#fn:4">Pink</a>
     img_src: ../../img/palettes/pink.png
+    img_title: to Pink Demo Page
     img_alt: Pink Demo Page
     link_href: ./pink/        
   - caption: <a id="fnref:5" class="footnote-ref" title="to image description" alt="to long image description" href="#fn:5">Sans</a>
     img_src: ../../img/palettes/sans.png
+    img_title: to Sans Demo Page
     img_alt: Sans Demo Page
     link_href: ./sans/    
   - caption: <a id="fnref:6" class="footnote-ref" title="to image description" alt="to long image description" href="#fn:6">Sans Dark</a>
     img_src: ../../img/palettes/sans_dark.png
+    img_title: to Sans Dark Demo Page 
     img_alt: Sans Dark Demo Page
     link_href: ./sans-dark/            
 ---

--- a/documentation/docs/configuration/palettes/index.md
+++ b/documentation/docs/configuration/palettes/index.md
@@ -5,6 +5,7 @@ tiles:
     img_src: ../../img/palettes/default.png
     img_alt: Default Demo Page
     link_href: ./default/
+    tile_css: img_link
   - caption: <a id="fnref:2" class="footnote-ref" title="to image description" alt="to long image description" href="#fn:2">Gruvbox Dark</a>
     img_src: ../../img/palettes/gruvbox_dark.png
     img_alt: Gruvbox Dark Demo Page
@@ -26,6 +27,12 @@ tiles:
     img_alt: Sans Dark Demo Page
     link_href: ./sans-dark/            
 ---
+<style> 
+  .img_link div:has(a:not(.footnote-ref):hover) {
+    color: var(--primary-color) !important;
+  }
+</style>
+
 # Theme Color Palettes
 Terminal for MkDocs subports the following color palettes by default:
 

--- a/documentation/docs/configuration/palettes/index.md
+++ b/documentation/docs/configuration/palettes/index.md
@@ -6,7 +6,6 @@ tiles:
     img_title: to Default Demo Page 
     img_alt: Default Demo Page
     link_href: ./default/
-    tile_css: img_link
   - caption: <a id="fnref:2" class="footnote-ref" title="to image description" alt="to long image description" href="#fn:2">Gruvbox Dark</a>
     img_src: ../../img/palettes/gruvbox_dark.png
     img_title: to Gruvbox Dark Demo Page
@@ -33,11 +32,6 @@ tiles:
     img_alt: Sans Dark Demo Page
     link_href: ./sans-dark/            
 ---
-<style> 
-  .img_link div:has(a:not(.footnote-ref):hover) {
-    color: var(--primary-color) !important;
-  }
-</style>
 
 # Theme Color Palettes
 Terminal for MkDocs subports the following color palettes by default:

--- a/documentation/docs/configuration/palettes/index.md
+++ b/documentation/docs/configuration/palettes/index.md
@@ -4,32 +4,32 @@ tiles:
   - caption: Default
     img_src: ../../img/palettes/default.png
     img_title: Default
-    img_alt: 'demo site with a white background and light blue hyperlinks.'
+    img_desc: 'demo site with a white background and light blue hyperlinks.'
     link_href: ./default/
   - caption: Gruvbox Dark
     img_src: ../../img/palettes/gruvbox_dark.png
     img_title: Gruvbox Dark
-    img_alt: 'demo site with a dark grey background, orange hyperlinks, and light yellow text.'
+    img_desc: 'demo site with a dark grey background, orange hyperlinks, and light yellow text.'
     link_href: ./gruvbox-dark/
   - caption: Dark
     img_src: ../../img/palettes/dark.png
     img_title: Dark
-    img_alt: 'demo site with a black background, light blue hyperlinks, and white text.'
+    img_desc: 'demo site with a black background, light blue hyperlinks, and white text.'
     link_href: ./dark/    
   - caption: Pink
     img_src: ../../img/palettes/pink.png
     img_title: Pink
-    img_alt: 'demo site with a white background and pink hyperlinks.'
+    img_desc: 'demo site with a white background and pink hyperlinks.'
     link_href: ./pink/        
   - caption: Sans
     img_src: ../../img/palettes/sans.png
     img_title: Sans
-    img_alt: 'demo site with a white background, light blue hyperlinks, and sans font.'
+    img_desc: 'demo site with a white background, light blue hyperlinks, and sans font.'
     link_href: ./sans/    
   - caption: Sans Dark
     img_src: ../../img/palettes/sans_dark.png
     img_title: Sans Dark
-    img_alt: 'demo site with a black background, light blue hyperlinks, and white text in sans font.'
+    img_desc: 'demo site with a black background, light blue hyperlinks, and white text in sans font.'
     link_href: ./sans-dark/            
 ---
 # Theme Color Palettes

--- a/documentation/docs/configuration/palettes/index.md
+++ b/documentation/docs/configuration/palettes/index.md
@@ -3,32 +3,32 @@ show_tiles_first: true
 tiles:
   - caption: Default
     img_src: ../../img/palettes/default.png
-    img_title: Default
+    img_alt: Default Demo Page
     img_desc: 'demo site with a white background and light blue hyperlinks.'
     link_href: ./default/
   - caption: Gruvbox Dark
     img_src: ../../img/palettes/gruvbox_dark.png
-    img_title: Gruvbox Dark
+    img_alt: Gruvbox Dark Demo Page
     img_desc: 'demo site with a dark grey background, orange hyperlinks, and light yellow text.'
     link_href: ./gruvbox-dark/
   - caption: Dark
     img_src: ../../img/palettes/dark.png
-    img_title: Dark
+    img_alt: Dark Demo Page
     img_desc: 'demo site with a black background, light blue hyperlinks, and white text.'
     link_href: ./dark/    
   - caption: Pink
     img_src: ../../img/palettes/pink.png
-    img_title: Pink
+    img_alt: Pink Demo Page
     img_desc: 'demo site with a white background and pink hyperlinks.'
     link_href: ./pink/        
   - caption: Sans
     img_src: ../../img/palettes/sans.png
-    img_title: Sans
+    img_alt: Sans Demo Page
     img_desc: 'demo site with a white background, light blue hyperlinks, and sans font.'
     link_href: ./sans/    
   - caption: Sans Dark
     img_src: ../../img/palettes/sans_dark.png
-    img_title: Sans Dark
+    img_alt: Sans Dark Demo Page
     img_desc: 'demo site with a black background, light blue hyperlinks, and white text in sans font.'
     link_href: ./sans-dark/            
 ---

--- a/documentation/docs/configuration/palettes/index.md
+++ b/documentation/docs/configuration/palettes/index.md
@@ -34,7 +34,7 @@ tiles:
 ---
 
 # Theme Color Palettes
-Terminal for MkDocs subports the following color palettes by default:
+Terminal for MkDocs supports the following color palettes by default:
 
   - [default](default.md)
   - [gruvbox_dark](gruvbox-dark.md)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "mkdocs-terminal",
-    "version": "3.10.2",
+    "version": "3.10.3",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mkdocs-terminal",
-    "version": "3.10.2",
+    "version": "3.10.3",
     "description": "Terminal.css theme for MkDocs",
     "keywords": [
         "mkdocs",

--- a/terminal/theme_version.html
+++ b/terminal/theme_version.html
@@ -1,1 +1,1 @@
-<meta name="generator" content="mkdocs-{{ mkdocs_version }}, mkdocs-terminal-3.10.2">
+<meta name="generator" content="mkdocs-{{ mkdocs_version }}, mkdocs-terminal-3.10.3">


### PR DESCRIPTION
- adds long image description to tile grid images
- uses footnotes to jump to long description
- updates image alt text to indicate that the image is being used as a link
- adds image title text to indicate that clicking on the image will take user to demo page


### References

experimental, supports investigation in #107 

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in [mkdocs-terminal/documentation](https://github.com/ntno/mkdocs-terminal/tree/main/documentation/docs)
- [x] All active GitHub checks for tests, formatting, and security are passing

