### PR TITLE
update documentation site

### DIFF
--- a/documentation/docs/about/license.md
+++ b/documentation/docs/about/license.md
@@ -1,5 +1,3 @@
----
----
 # MIT License
 
 Copyright (c) 2023 Natan Organick

--- a/documentation/docs/releases.md
+++ b/documentation/docs/releases.md
@@ -24,6 +24,7 @@ See [Version Identification and Dependency Specification] for additional constra
 
 | Release | Theme Status | Supported? |
 | :-----: | :----------: | :--------: |
+| [4.3.0] |     Beta     |    yes     |
 | [4.1.0] |     Beta     |    yes     |
 | [3.9.0] |    Alpha     |     no     |
 | [3.7.0] |    Alpha     |     no     |
@@ -32,6 +33,7 @@ See [Version Identification and Dependency Specification] for additional constra
 
 
 <br>
+[4.3.0]: https://github.com/ntno/mkdocs-terminal/releases/tag/4.3.0
 [4.1.0]: https://github.com/ntno/mkdocs-terminal/releases/tag/4.1.0
 [3.9.0]: https://github.com/ntno/mkdocs-terminal/releases/tag/3.9.0
 [3.7.0]: https://github.com/ntno/mkdocs-terminal/releases/tag/3.7.0

--- a/documentation/mkdocs.yml
+++ b/documentation/mkdocs.yml
@@ -100,6 +100,7 @@ theme:
   name: terminal
   custom_dir: theme_overrides
   features:
+    - footer.prev_next
     - navigation.side.indexes
     - revision.date
     - revision.history

--- a/documentation/requirements.txt
+++ b/documentation/requirements.txt
@@ -1,5 +1,5 @@
 mkdocs
-mkdocs-terminal~=4.0
+mkdocs-terminal~=4.3
 
 # Python Markdown Extensions
 pygments>=2.14


### PR DESCRIPTION
- set minimum version to 4.3.0
- turn on prev/next feature
- add link to 4.3.0 on release page
- fixed formatting issue on license page