### PR TITLE
class=terminal should be a toggle

### DIFF
--- a/terminal/base.html
+++ b/terminal/base.html
@@ -37,7 +37,7 @@
     {% block analytics %}{% endblock analytics %}
 </head>
 
-<body {%- block body_attrs %}class="terminal"{%- endblock body_attrs %}>
+<body {% block body_attrs %}class="terminal"{% endblock body_attrs %}>
     {%- block top_nav %}{% include "partials/top-nav/top.html" %}{%- endblock top_nav %}
         
     <div class="container">

--- a/terminal/base.html
+++ b/terminal/base.html
@@ -37,7 +37,7 @@
     {% block analytics %}{% endblock analytics %}
 </head>
 
-<body class="terminal">
+<body {%- block body_attrs %}class="terminal"{%- endblock body_attrs %}>
     {%- block top_nav %}{% include "partials/top-nav/top.html" %}{%- endblock top_nav %}
         
     <div class="container">


### PR DESCRIPTION
### Description

Adds the ability to change the body's attributes, allowing users to disable the default `class="terminal"` which standardizes all headers to be the same size. Opening this PR as a float towards the idea before adding documentation, etc.

### Testing

Manually tested by creating a mkdocs-terminal that overrides main.html with the following version.

```python
{% extends "base.html" %}
{% block body_attrs %}
{% endblock body_attrs %}
```

Direction on where to add an automated test would be appreciated

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in [mkdocs-terminal/documentation](https://github.com/ntno/mkdocs-terminal/tree/main/documentation/docs)
- [ ] All active GitHub checks for tests, formatting, and security are passing

