### PR TITLE
Sticky sidebar

### DIFF
--- a/terminal/base.html
+++ b/terminal/base.html
@@ -42,7 +42,10 @@
         
     <div class="container">
         <div class="terminal-mkdocs-main-grid">
-          {%- block side_panel %}{% include "partials/side-panel/side-panel.html" %}{%- endblock side_panel %}
+            <!-- div required for sticky side panel -->
+            <div> 
+                {%- block side_panel %}{% include "partials/side-panel/side-panel.html" %}{%- endblock side_panel %}
+            </div>
             <main id="terminal-mkdocs-main-content">
                 {%- block content_container %}{% include "partials/page.html" %}{%- endblock content_container %}
             </main>

--- a/terminal/css/terminal.css
+++ b/terminal/css/terminal.css
@@ -853,6 +853,9 @@ textarea:-webkit-autofill:hover textarea:-webkit-autofill:focus {
     .terminal-menu li:last-child {
         margin-right: 0;
     }
+    .terminal-mkdocs-main-grid {
+        position: block;
+    }
 }
 
 .terminal-media:not(:last-child) {

--- a/terminal/css/terminal.css
+++ b/terminal/css/terminal.css
@@ -2,17 +2,17 @@
 
 * {
     box-sizing: border-box;
-    text-rendering: geometricPrecision
+    text-rendering: geometricPrecision;
 }
 
 ::-moz-selection {
     background: var(--primary-color);
-    color: var(--invert-font-color)
+    color: var(--invert-font-color);
 }
 
 ::selection {
     background: var(--primary-color);
-    color: var(--invert-font-color)
+    color: var(--invert-font-color);
 }
 
 body {
@@ -22,7 +22,7 @@ body {
     margin: 0;
     font-family: var(--font-stack);
     word-wrap: break-word;
-    background-color: var(--background-color)
+    background-color: var(--background-color);
 }
 
 .logo,
@@ -32,32 +32,32 @@ h3,
 h4,
 h5,
 h6 {
-    line-height: var(--global-line-height)
+    line-height: var(--global-line-height);
 }
 
 a {
     cursor: pointer;
     color: var(--primary-color);
-    text-decoration: none
+    text-decoration: none;
 }
 
 a:hover {
     background-color: var(--primary-color);
-    color: var(--invert-font-color)
+    color: var(--invert-font-color);
 }
 
 em {
     font-size: var(--global-font-size);
     font-style: italic;
     font-family: var(--font-stack);
-    color: var(--font-color)
+    color: var(--font-color);
 }
 
 blockquote,
 code,
 em,
 strong {
-    line-height: var(--global-line-height)
+    line-height: var(--global-line-height);
 }
 
 .logo,
@@ -78,7 +78,7 @@ section,
 ul {
     float: none;
     margin: 0;
-    padding: 0
+    padding: 0;
 }
 
 .logo,
@@ -88,7 +88,7 @@ ol,
 p,
 ul {
     margin-top: calc(var(--global-space) * 2);
-    margin-bottom: calc(var(--global-space) * 2)
+    margin-bottom: calc(var(--global-space) * 2);
 }
 
 .logo,
@@ -99,7 +99,7 @@ h1 {
     padding: calc(var(--global-space) * 2) 0 calc(var(--global-space) * 2);
     margin: 0;
     overflow: hidden;
-    font-weight: 600
+    font-weight: 600;
 }
 
 h1::after {
@@ -107,12 +107,12 @@ h1::after {
     position: absolute;
     bottom: 5px;
     left: 0;
-    display: var(--display-h1-decoration)
+    display: var(--display-h1-decoration);
 }
 
-.logo+*,
-h1+* {
-    margin-top: 0
+.logo + *,
+h1 + * {
+    margin-top: 0;
 }
 
 h2,
@@ -122,14 +122,14 @@ h5,
 h6 {
     position: relative;
     margin-bottom: var(--global-line-height);
-    font-weight: 600
+    font-weight: 600;
 }
 
 blockquote {
     position: relative;
     padding-left: calc(var(--global-space) * 2);
     padding-left: 2ch;
-    overflow: hidden
+    overflow: hidden;
 }
 
 blockquote::after {
@@ -139,24 +139,24 @@ blockquote::after {
     top: 0;
     left: 0;
     line-height: var(--global-line-height);
-    color: #9ca2ab
+    color: #9ca2ab;
 }
 
 code {
     font-weight: inherit;
     background-color: var(--code-bg-color);
-    font-family: var(--mono-font-stack)
+    font-family: var(--mono-font-stack);
 }
 
 code::after,
 code::before {
     content: "`";
-    display: inline
+    display: inline;
 }
 
 pre code::after,
 pre code::before {
-    content: ""
+    content: "";
 }
 
 pre {
@@ -170,7 +170,7 @@ pre {
     white-space: pre-wrap;
     white-space: -moz-pre-wrap;
     white-space: -pre-wrap;
-    white-space: -o-pre-wrap
+    white-space: -o-pre-wrap;
 }
 
 pre code {
@@ -179,7 +179,7 @@ pre code {
     margin: 0;
     display: inline-block;
     min-width: 100%;
-    font-family: var(--mono-font-stack)
+    font-family: var(--mono-font-stack);
 }
 
 .terminal .logo,
@@ -195,149 +195,149 @@ pre code {
     font-size: var(--global-font-size);
     font-style: normal;
     font-family: var(--font-stack);
-    color: var(--font-color)
+    color: var(--font-color);
 }
 
 .terminal-prompt {
     position: relative;
-    white-space: nowrap
+    white-space: nowrap;
 }
 
 .terminal-prompt::before {
-    content: "> "
+    content: "> ";
 }
 
 .terminal-prompt::after {
     content: "";
-    -webkit-animation: cursor .8s infinite;
-    animation: cursor .8s infinite;
+    -webkit-animation: cursor 0.8s infinite;
+    animation: cursor 0.8s infinite;
     background: var(--primary-color);
     border-radius: 0;
     display: inline-block;
     height: 1em;
-    margin-left: .2em;
+    margin-left: 0.2em;
     width: 3px;
     bottom: -2px;
-    position: relative
+    position: relative;
 }
 
 @-webkit-keyframes cursor {
     0% {
-        opacity: 0
+        opacity: 0;
     }
     50% {
-        opacity: 1
+        opacity: 1;
     }
     to {
-        opacity: 0
+        opacity: 0;
     }
 }
 
 @keyframes cursor {
     0% {
-        opacity: 0
+        opacity: 0;
     }
     50% {
-        opacity: 1
+        opacity: 1;
     }
     to {
-        opacity: 0
+        opacity: 0;
     }
 }
 
 li,
-li>ul>li {
+li > ul > li {
     position: relative;
     display: block;
-    padding-left: calc(var(--global-space) * 2)
+    padding-left: calc(var(--global-space) * 2);
 }
 
-nav>ul>li {
-    padding-left: 0
+nav > ul > li {
+    padding-left: 0;
 }
 
 li::after {
     position: absolute;
     top: 0;
-    left: 0
+    left: 0;
 }
 
-ul>li::after {
-    content: "-"
+ul > li::after {
+    content: "-";
 }
 
-nav ul>li::after {
-    content: ""
+nav ul > li::after {
+    content: "";
 }
 
 ol li::before {
     content: counters(item, ".") ". ";
-    counter-increment: item
+    counter-increment: item;
 }
 
 ol ol li::before {
     content: counters(item, ".") " ";
-    counter-increment: item
+    counter-increment: item;
 }
 
 .terminal-menu li::after,
 .terminal-menu li::before {
-    display: none
+    display: none;
 }
 
 ol {
-    counter-reset: item
+    counter-reset: item;
 }
 
-ol li:nth-child(n+10)::after {
-    left: -7px
+ol li:nth-child(n + 10)::after {
+    left: -7px;
 }
 
 ol ol {
     margin-top: 0;
-    margin-bottom: 0
+    margin-bottom: 0;
 }
 
 .terminal-menu {
-    width: 100%
+    width: 100%;
 }
 
 .terminal-nav {
     display: flex;
     flex-direction: column;
-    align-items: flex-start
+    align-items: flex-start;
 }
 
 ul ul {
     margin-top: 0;
-    margin-bottom: 0
+    margin-bottom: 0;
 }
 
 .terminal-menu ul {
     list-style-type: none;
-    padding: 0!important;
+    padding: 0 !important;
     display: flex;
     flex-direction: column;
     width: 100%;
     flex-grow: 1;
     font-size: var(--global-font-size);
-    margin-top: 0
+    margin-top: 0;
 }
 
 .terminal-menu li {
     display: flex;
-    margin: 0 0 .5em 0;
-    padding: 0
+    margin: 0 0 0.5em 0;
+    padding: 0;
 }
 
 ol.terminal-toc li {
     border-bottom: 1px dotted var(--secondary-color);
     padding: 0;
-    margin-bottom: 15px
+    margin-bottom: 15px;
 }
 
 .terminal-menu li:last-child {
-    margin-bottom: 0
+    margin-bottom: 0;
 }
 
 ol.terminal-toc li a {
@@ -346,7 +346,7 @@ ol.terminal-toc li a {
     position: relative;
     top: 6px;
     text-align: left;
-    padding-right: 4px
+    padding-right: 4px;
 }
 
 .terminal-menu li a:not(.btn) {
@@ -354,16 +354,16 @@ ol.terminal-toc li a {
     display: block;
     width: 100%;
     border: none;
-    color: var(--secondary-color)
+    color: var(--secondary-color);
 }
 
 .terminal-menu li a.active {
-    color: var(--font-color)
+    color: var(--font-color);
 }
 
 .terminal-menu li a:hover {
     background: 0 0;
-    color: inherit
+    color: inherit;
 }
 
 ol.terminal-toc li::before {
@@ -373,12 +373,12 @@ ol.terminal-toc li::before {
     right: 0;
     background: var(--background-color);
     padding: 4px 0 4px 4px;
-    bottom: -8px
+    bottom: -8px;
 }
 
 ol.terminal-toc li a:hover {
     background: var(--primary-color);
-    color: var(--invert-font-color)
+    color: var(--invert-font-color);
 }
 
 hr {
@@ -386,44 +386,49 @@ hr {
     overflow: hidden;
     margin: calc(var(--global-space) * 4) 0;
     border: 0;
-    border-bottom: 1px dashed var(--secondary-color)
+    border-bottom: 1px dashed var(--secondary-color);
 }
 
 p {
     margin: 0 0 var(--global-line-height);
-    color: var(--global-font-color)
+    color: var(--global-font-color);
 }
 
 .container {
-    max-width: var(--page-width)
+    max-width: var(--page-width);
 }
 
 .container,
 .container-fluid {
     margin: 0 auto;
-    padding: 0 calc(var(--global-space) * 2)
+    padding: 0 calc(var(--global-space) * 2);
+}
+
+.terminal-mkdocs-main-grid aside {
+    position: sticky;
+    top: calc(var(--global-space) * 2);
 }
 
 img {
-    width: 100%
+    width: 100%;
 }
 
 .progress-bar {
     height: 8px;
     background-color: var(--progress-bar-background);
-    margin: 12px 0
+    margin: 12px 0;
 }
 
 .progress-bar.progress-bar-show-percent {
-    margin-top: 38px
+    margin-top: 38px;
 }
 
 .progress-bar-filled {
     background-color: var(--progress-bar-fill);
     height: 100%;
-    transition: width .3s ease;
+    transition: width 0.3s ease;
     position: relative;
-    width: 0
+    width: 0;
 }
 
 .progress-bar-filled::before {
@@ -432,7 +437,7 @@ img {
     border-top-color: var(--progress-bar-fill);
     position: absolute;
     top: -12px;
-    right: -6px
+    right: -6px;
 }
 
 .progress-bar-filled::after {
@@ -445,15 +450,15 @@ img {
     border: 6px solid transparent;
     top: -38px;
     right: 0;
-    transform: translateX(50%)
+    transform: translateX(50%);
 }
 
-.progress-bar-no-arrow>.progress-bar-filled::after,
-.progress-bar-no-arrow>.progress-bar-filled::before {
+.progress-bar-no-arrow > .progress-bar-filled::after,
+.progress-bar-no-arrow > .progress-bar-filled::before {
     content: "";
     display: none;
     visibility: hidden;
-    opacity: 0
+    opacity: 0;
 }
 
 table {
@@ -461,7 +466,7 @@ table {
     border-collapse: collapse;
     margin: var(--global-line-height) 0;
     color: var(--font-color);
-    font-size: var(--global-font-size)
+    font-size: var(--global-font-size);
 }
 
 table td,
@@ -469,113 +474,113 @@ table th {
     vertical-align: top;
     border: 1px solid var(--font-color);
     line-height: var(--global-line-height);
-    padding: calc(var(--global-space)/ 2);
-    font-size: 1em
+    padding: calc(var(--global-space) / 2);
+    font-size: 1em;
 }
 
 table thead th {
-    font-size: 1em
+    font-size: 1em;
 }
 
 table tfoot tr th {
-    font-weight: 500
+    font-weight: 500;
 }
 
 table caption {
     font-size: 1em;
-    margin: 0 0 1em 0
+    margin: 0 0 1em 0;
 }
 
 table tbody td:first-child {
     font-weight: 700;
-    color: var(--secondary-color)
+    color: var(--secondary-color);
 }
 
 .form {
-    width: 100%
+    width: 100%;
 }
 
 fieldset {
     border: 1px solid var(--font-color);
-    padding: 1em
+    padding: 1em;
 }
 
 label {
     font-size: 1em;
-    color: var(--font-color)
+    color: var(--font-color);
 }
 
-input[type=email],
-input[type=number],
-input[type=password],
-input[type=search],
-input[type=text] {
+input[type="email"],
+input[type="number"],
+input[type="password"],
+input[type="search"],
+input[type="text"] {
     border: 1px var(--input-style) var(--font-color);
     width: 100%;
-    padding: .7em .5em;
+    padding: 0.7em 0.5em;
     font-size: 1em;
     font-family: var(--font-stack);
     -webkit-appearance: none;
-    border-radius: 0
+    border-radius: 0;
 }
 
-input[type=email]:active,
-input[type=email]:focus,
-input[type=number]:active,
-input[type=number]:focus,
-input[type=password]:active,
-input[type=password]:focus,
-input[type=search]:active,
-input[type=search]:focus,
-input[type=text]:active,
-input[type=text]:focus {
+input[type="email"]:active,
+input[type="email"]:focus,
+input[type="number"]:active,
+input[type="number"]:focus,
+input[type="password"]:active,
+input[type="password"]:focus,
+input[type="search"]:active,
+input[type="search"]:focus,
+input[type="text"]:active,
+input[type="text"]:focus {
     outline: 0;
     -webkit-appearance: none;
-    border: 1px solid var(--font-color)
+    border: 1px solid var(--font-color);
 }
 
-input[type=email]:not(:placeholder-shown):invalid,
-input[type=number]:not(:placeholder-shown):invalid,
-input[type=password]:not(:placeholder-shown):invalid,
-input[type=search]:not(:placeholder-shown):invalid,
-input[type=text]:not(:placeholder-shown):invalid {
-    border-color: var(--error-color)
+input[type="email"]:not(:placeholder-shown):invalid,
+input[type="number"]:not(:placeholder-shown):invalid,
+input[type="password"]:not(:placeholder-shown):invalid,
+input[type="search"]:not(:placeholder-shown):invalid,
+input[type="text"]:not(:placeholder-shown):invalid {
+    border-color: var(--error-color);
 }
 
 input,
 textarea {
     color: var(--font-color);
-    background-color: var(--background-color)
+    background-color: var(--background-color);
 }
 
 input::-webkit-input-placeholder,
 textarea::-webkit-input-placeholder {
-    color: var(--secondary-color)!important;
-    opacity: 1
+    color: var(--secondary-color) !important;
+    opacity: 1;
 }
 
 input::-moz-placeholder,
 textarea::-moz-placeholder {
-    color: var(--secondary-color)!important;
-    opacity: 1
+    color: var(--secondary-color) !important;
+    opacity: 1;
 }
 
 input:-ms-input-placeholder,
 textarea:-ms-input-placeholder {
-    color: var(--secondary-color)!important;
-    opacity: 1
+    color: var(--secondary-color) !important;
+    opacity: 1;
 }
 
 input::-ms-input-placeholder,
 textarea::-ms-input-placeholder {
-    color: var(--secondary-color)!important;
-    opacity: 1
+    color: var(--secondary-color) !important;
+    opacity: 1;
 }
 
 input::placeholder,
 textarea::placeholder {
-    color: var(--secondary-color)!important;
-    opacity: 1
+    color: var(--secondary-color) !important;
+    opacity: 1;
 }
 
 textarea {
@@ -583,21 +588,21 @@ textarea {
     width: 100%;
     resize: none;
     border: 1px var(--input-style) var(--font-color);
-    padding: .5em;
+    padding: 0.5em;
     font-size: 1em;
     font-family: var(--font-stack);
     -webkit-appearance: none;
-    border-radius: 0
+    border-radius: 0;
 }
 
 textarea:focus {
     outline: 0;
     -webkit-appearance: none;
-    border: 1px solid var(--font-color)
+    border: 1px solid var(--font-color);
 }
 
 textarea:not(:placeholder-shown):invalid {
-    border-color: var(--error-color)
+    border-color: var(--error-color);
 }
 
 input:-webkit-autofill,
@@ -611,12 +616,12 @@ textarea:-webkit-autofill:hover textarea:-webkit-autofill:focus {
     -webkit-text-fill-color: var(--font-color);
     box-shadow: 0 0 0 1000px var(--invert-font-color) inset;
     -webkit-box-shadow: 0 0 0 1000px var(--invert-font-color) inset;
-    transition: background-color 5000s ease-in-out 0s
+    transition: background-color 5000s ease-in-out 0s;
 }
 
 .form-group {
     margin-bottom: var(--global-line-height);
-    overflow: auto
+    overflow: auto;
 }
 
 .btn {
@@ -627,7 +632,7 @@ textarea:-webkit-autofill:hover textarea:-webkit-autofill:focus {
     justify-content: center;
     cursor: pointer;
     outline: 0;
-    padding: .65em 2em;
+    padding: 0.65em 2em;
     font-size: 1em;
     font-family: inherit;
     -webkit-user-select: none;
@@ -635,156 +640,156 @@ textarea:-webkit-autofill:hover textarea:-webkit-autofill:focus {
     -ms-user-select: none;
     user-select: none;
     position: relative;
-    z-index: 1
+    z-index: 1;
 }
 
 .btn:active {
-    box-shadow: none
+    box-shadow: none;
 }
 
 .btn.btn-ghost {
     border-color: var(--font-color);
     color: var(--font-color);
-    background-color: transparent
+    background-color: transparent;
 }
 
 .btn.btn-ghost:focus,
 .btn.btn-ghost:hover {
     border-color: var(--tertiary-color);
     color: var(--tertiary-color);
-    z-index: 2
+    z-index: 2;
 }
 
 .btn.btn-ghost:hover {
-    background-color: transparent
+    background-color: transparent;
 }
 
 .btn-block {
     width: 100%;
-    display: flex
+    display: flex;
 }
 
 .btn-default {
     background-color: var(--font-color);
     border-color: var(--invert-font-color);
-    color: var(--invert-font-color)
+    color: var(--invert-font-color);
 }
 
 .btn-default:focus:not(.btn-ghost),
 .btn-default:hover {
     background-color: var(--secondary-color);
-    color: var(--invert-font-color)
+    color: var(--invert-font-color);
 }
 
 .btn-default.btn-ghost:focus,
 .btn-default.btn-ghost:hover {
     border-color: var(--secondary-color);
     color: var(--secondary-color);
-    z-index: 2
+    z-index: 2;
 }
 
 .btn-error {
     color: var(--invert-font-color);
     background-color: var(--error-color);
-    border: 1px solid var(--error-color)
+    border: 1px solid var(--error-color);
 }
 
 .btn-error:focus:not(.btn-ghost),
 .btn-error:hover {
     background-color: var(--error-color);
-    border-color: var(--error-color)
+    border-color: var(--error-color);
 }
 
 .btn-error.btn-ghost {
     border-color: var(--error-color);
-    color: var(--error-color)
+    color: var(--error-color);
 }
 
 .btn-error.btn-ghost:focus,
 .btn-error.btn-ghost:hover {
     border-color: var(--error-color);
     color: var(--error-color);
-    z-index: 2
+    z-index: 2;
 }
 
 .btn-primary {
     color: var(--invert-font-color);
     background-color: var(--primary-color);
-    border: 1px solid var(--primary-color)
+    border: 1px solid var(--primary-color);
 }
 
 .btn-primary:focus:not(.btn-ghost),
 .btn-primary:hover {
     background-color: var(--primary-color);
-    border-color: var(--primary-color)
+    border-color: var(--primary-color);
 }
 
 .btn-primary.btn-ghost {
     border-color: var(--primary-color);
-    color: var(--primary-color)
+    color: var(--primary-color);
 }
 
 .btn-primary.btn-ghost:focus,
 .btn-primary.btn-ghost:hover {
     border-color: var(--primary-color);
     color: var(--primary-color);
-    z-index: 2
+    z-index: 2;
 }
 
 .btn-small {
-    padding: .5em 1.3em!important;
-    font-size: .9em!important
+    padding: 0.5em 1.3em !important;
+    font-size: 0.9em !important;
 }
 
 .btn-group {
-    overflow: auto
+    overflow: auto;
 }
 
 .btn-group .btn {
-    float: left
+    float: left;
 }
 
 .btn-group .btn-ghost:not(:first-child) {
-    margin-left: -1px
+    margin-left: -1px;
 }
 
 .terminal-card {
-    border: 1px solid var(--secondary-color)
+    border: 1px solid var(--secondary-color);
 }
 
-.terminal-card>header {
+.terminal-card > header {
     color: var(--invert-font-color);
     text-align: center;
     background-color: var(--secondary-color);
-    padding: .5em 0
+    padding: 0.5em 0;
 }
 
-.terminal-card>div:first-of-type {
-    padding: var(--global-space)
+.terminal-card > div:first-of-type {
+    padding: var(--global-space);
 }
 
 .terminal-timeline {
     position: relative;
-    padding-left: 70px
+    padding-left: 70px;
 }
 
 .terminal-timeline::before {
-    content: ' ';
+    content: " ";
     background: var(--secondary-color);
     display: inline-block;
     position: absolute;
     left: 35px;
     width: 2px;
     height: 100%;
-    z-index: 400
+    z-index: 400;
 }
 
 .terminal-timeline .terminal-card {
-    margin-bottom: 25px
+    margin-bottom: 25px;
 }
 
 .terminal-timeline .terminal-card::before {
-    content: ' ';
+    content: " ";
     background: var(--invert-font-color);
     border: 2px solid var(--secondary-color);
     display: inline-block;
@@ -793,93 +798,93 @@ textarea:-webkit-autofill:hover textarea:-webkit-autofill:focus {
     left: 26px;
     width: 15px;
     height: 15px;
-    z-index: 400
+    z-index: 400;
 }
 
 .terminal-alert {
     color: var(--font-color);
     padding: 1em;
     border: 1px solid var(--font-color);
-    margin-bottom: var(--global-space)
+    margin-bottom: var(--global-space);
 }
 
 .terminal-alert-error {
     color: var(--error-color);
-    border-color: var(--error-color)
+    border-color: var(--error-color);
 }
 
 .terminal-alert-primary {
     color: var(--primary-color);
-    border-color: var(--primary-color)
+    border-color: var(--primary-color);
 }
 
-@media screen and (max-width:960px) {
+@media screen and (max-width: 960px) {
     label {
         display: block;
-        width: 100%
+        width: 100%;
     }
     pre::-webkit-scrollbar {
-        height: 3px
+        height: 3px;
     }
 }
 
-@media screen and (max-width:480px) {
+@media screen and (max-width: 480px) {
     form {
-        width: 100%
+        width: 100%;
     }
 }
 
-@media only screen and (min-width:30em) {
+@media only screen and (min-width: 30em) {
     .terminal-nav {
         flex-direction: row;
-        align-items: center
+        align-items: center;
     }
     .terminal-menu ul {
         flex-direction: row;
         justify-items: flex-end;
         align-items: center;
         justify-content: flex-end;
-        margin-top: calc(var(--global-space) * 2)
+        margin-top: calc(var(--global-space) * 2);
     }
     .terminal-menu li {
         margin: 0;
-        margin-right: 2em
+        margin-right: 2em;
     }
     .terminal-menu li:last-child {
-        margin-right: 0
+        margin-right: 0;
     }
 }
 
 .terminal-media:not(:last-child) {
-    margin-bottom: 1.25rem
+    margin-bottom: 1.25rem;
 }
 
 .terminal-media-left {
-    padding-right: var(--global-space)
+    padding-right: var(--global-space);
 }
 
 .terminal-media-left,
 .terminal-media-right {
     display: table-cell;
-    vertical-align: top
+    vertical-align: top;
 }
 
 .terminal-media-right {
-    padding-left: var(--global-space)
+    padding-left: var(--global-space);
 }
 
 .terminal-media-body {
     display: table-cell;
-    vertical-align: top
+    vertical-align: top;
 }
 
 .terminal-media-heading {
     font-size: 1em;
-    font-weight: 700
+    font-weight: 700;
 }
 
 .terminal-media-content {
-    margin-top: .3rem
+    margin-top: 0.3rem;
 }
 
 .terminal-placeholder {
@@ -887,46 +892,46 @@ textarea:-webkit-autofill:hover textarea:-webkit-autofill:focus {
     text-align: center;
     color: var(--font-color);
     font-size: 1rem;
-    border: 1px solid var(--secondary-color)
+    border: 1px solid var(--secondary-color);
 }
 
-figure>img {
-    padding: 0
+figure > img {
+    padding: 0;
 }
 
 .terminal-avatarholder {
     width: calc(var(--global-space) * 5);
-    height: calc(var(--global-space) * 5)
+    height: calc(var(--global-space) * 5);
 }
 
 .terminal-avatarholder img {
-    padding: 0
+    padding: 0;
 }
 
 figure {
-    margin: 0
+    margin: 0;
 }
 
-figure>figcaption {
+figure > figcaption {
     color: var(--secondary-color);
-    text-align: center
+    text-align: center;
 }
 
 .hljs {
     display: block;
     overflow-x: auto;
-    padding: .5em;
+    padding: 0.5em;
     background: var(--block-background-color);
-    color: var(--font-color)
+    color: var(--font-color);
 }
 
 .hljs-comment,
 .hljs-quote {
-    color: var(--secondary-color)
+    color: var(--secondary-color);
 }
 
 .hljs-variable {
-    color: var(--font-color)
+    color: var(--font-color);
 }
 
 .hljs-built_in,
@@ -934,7 +939,7 @@ figure>figcaption {
 .hljs-name,
 .hljs-selector-tag,
 .hljs-tag {
-    color: var(--primary-color)
+    color: var(--primary-color);
 }
 
 .hljs-addition,
@@ -946,38 +951,38 @@ figure>figcaption {
 .hljs-template-variable,
 .hljs-title,
 .hljs-type {
-    color: var(--secondary-color)
+    color: var(--secondary-color);
 }
 
 .hljs-string {
-    color: var(--secondary-color)
+    color: var(--secondary-color);
 }
 
 .hljs-deletion,
 .hljs-meta,
 .hljs-selector-attr,
 .hljs-selector-pseudo {
-    color: var(--primary-color)
+    color: var(--primary-color);
 }
 
 .hljs-doctag {
-    color: var(--secondary-color)
+    color: var(--secondary-color);
 }
 
 .hljs-attr {
-    color: var(--primary-color)
+    color: var(--primary-color);
 }
 
 .hljs-bullet,
 .hljs-link,
 .hljs-symbol {
-    color: var(--primary-color)
+    color: var(--primary-color);
 }
 
 .hljs-emphasis {
-    font-style: italic
+    font-style: italic;
 }
 
 .hljs-strong {
-    font-weight: 700
+    font-weight: 700;
 }


### PR DESCRIPTION
Resolves #140 

### Description

> Describe the purpose of this PR along with any background information and the impacts of the proposed change. For the benefit of the community, please do not assume prior context.
>
> Provide details that support your chosen implementation, including: breaking changes, alternatives considered, changes to the API, etc.
>
> If the UI is being changed, please provide before/after screenshots.

Sticky sidebars are a great UI functionality, as the user doesn't need to scroll up to access menu / nav items. This PR implements this behaviour idiomatically with the original `terminal.css` approach and uses global variables for spacing that are already in use within the code base.

This is a draft PR for now as merging in the current state would create a 'breaking change' of sorts to current users. Their sidebars would all become sticky by default.

I'm therefore looking for some feedback as how best to toggle this functionality via theme options, e.g, `navigation.side.sticky = true`

`{%- if "navigation.side.sticky" in features -%} make sticky {%- endif -%}` 

I tried to create an `if - else` block in `side-panel.html` to insert the div elements required for the sticky sidebar. As without `div` elements, the sidebar will not stick (also a bit of a hacky solution?). Along the lines of this. But I get an error about `block side_nav` being included twice:

```html
{%- set features = config.theme.features or [] -%}
{%- if "navigation.side.hide" not in features -%}
{%- if "navigation.side.sticky" in features -%}
<div>
<aside id="terminal-mkdocs-side-panel">
    {%- block side_nav %}{% include "partials/side-nav/side-nav.html" %}{%- endblock side_nav %}
    {%- block side_toc %}{% include "partials/side-panel/side-toc.html" %}{%- endblock side_toc %}
</aside>
</div>
{%- else -%}
<aside id="terminal-mkdocs-side-panel">
    {%- block side_nav %}{% include "partials/side-nav/side-nav.html" %}{%- endblock side_nav %}
    {%- block side_toc %}{% include "partials/side-panel/side-toc.html" %}{%- endblock side_toc %}
</aside>
{%- endif -%}
{%- endif -%}

```

```diff
- Unfortunately, my formatter also found a lot of missing semi-colons in `terminal.css`. 
- I didn't realise it made this change when saving and committing... 
- Makes the pr a bit messy. Lines of implementation in `terminal.css` are 407 and 856.
```

### Testing

The theme can be built and served directly: `make build-locally-and-serve`.

Then select a menu item that shows a page with enough content to scroll, and scroll down the page.
Make a narrow screen so the sidebars become top flex boxes, and scroll again (sidebar is static again).

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in [mkdocs-terminal/documentation](https://github.com/ntno/mkdocs-terminal/tree/main/documentation/docs)
- [ ] All active GitHub checks for tests, formatting, and security are passing

