### PR TITLE
Upgrade to terminal 0.7.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mkdocs-terminal",
-    "version": "4.4.0",
+    "version": "4.5.0",
     "description": "Terminal.css theme for MkDocs",
     "keywords": [
         "mkdocs",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     },
     "scripts": {},
     "dependencies": {
-        "terminal.css": "^0.7.2"
+        "terminal.css": "^0.7.4"
     },
     "devDependencies": {},
     "engines": {

--- a/terminal/css/palettes/dark.css
+++ b/terminal/css/palettes/dark.css
@@ -1,26 +1,22 @@
-/*! dark.css 0.7.2 | MIT License | github.com/Gioni06/terminal.css */
+/*! dark.css 0.7.4 | MIT License | github.com/Gioni06/terminal.css */
 
 :root {
     --global-font-size: 15px;
     --global-line-height: 1.4em;
     --global-space: 10px;
-    --font-stack: Menlo, Monaco, Lucida Console, Liberation Mono,
-      DejaVu Sans Mono, Bitstream Vera Sans Mono, Courier New, monospace,
-      serif;
-    --mono-font-stack: Menlo, Monaco, Lucida Console, Liberation Mono,
-      DejaVu Sans Mono, Bitstream Vera Sans Mono, Courier New, monospace,
-      serif;
+    --font-stack: "Menlo", "Monaco", "Lucida Console", "Liberation Mono", "DejaVu Sans Mono", "Bitstream Vera Sans Mono", "Courier New", monospace, serif;
+    --mono-font-stack: "Menlo", "Monaco", "Lucida Console", "Liberation Mono", "DejaVu Sans Mono", "Bitstream Vera Sans Mono", "Courier New", monospace, serif;
     --background-color: #222225;
     --page-width: 60em;
     --font-color: #e8e9ed;
     --invert-font-color: #222225;
-    --primary-color: #62c4ff;
     --secondary-color: #a3abba;
     --tertiary-color: #a3abba;
+    --primary-color: #62c4ff;
     --error-color: #ff3c74;
     --progress-bar-background: #3f3f44;
     --progress-bar-fill: #62c4ff;
     --code-bg-color: #3f3f44;
     --input-style: solid;
     --display-h1-decoration: none;
-  }
+}

--- a/terminal/css/palettes/dark.css
+++ b/terminal/css/palettes/dark.css
@@ -4,8 +4,8 @@
     --global-font-size: 15px;
     --global-line-height: 1.4em;
     --global-space: 10px;
-    --font-stack: "Menlo", "Monaco", "Lucida Console", "Liberation Mono", "DejaVu Sans Mono", "Bitstream Vera Sans Mono", "Courier New", monospace, serif;
-    --mono-font-stack: "Menlo", "Monaco", "Lucida Console", "Liberation Mono", "DejaVu Sans Mono", "Bitstream Vera Sans Mono", "Courier New", monospace, serif;
+    --font-stack: Menlo, Monaco, Lucida Console, Liberation Mono, DejaVu Sans Mono, Bitstream Vera Sans Mono, Courier New, monospace, serif;
+    --mono-font-stack: Menlo, Monaco, Lucida Console, Liberation Mono, DejaVu Sans Mono, Bitstream Vera Sans Mono, Courier New, monospace, serif;
     --background-color: #222225;
     --page-width: 60em;
     --font-color: #e8e9ed;

--- a/terminal/css/palettes/default.css
+++ b/terminal/css/palettes/default.css
@@ -1,22 +1,4 @@
 /*! terminal.css 0.7.4 | MIT License | github.com/Gioni06/terminal.css */
 
-:root {
-    --global-font-size: 15px;
-    --global-line-height: 1.4em;
-    --global-space: 10px;
-    --font-stack: "Menlo", "Monaco", "Lucida Console", "Liberation Mono", "DejaVu Sans Mono", "Bitstream Vera Sans Mono", "Courier New", serif;
-    --mono-font-stack: "Menlo", "Monaco", "Lucida Console", "Liberation Mono", "DejaVu Sans Mono", "Bitstream Vera Sans Mono", "Courier New", serif;
-    --background-color: #fff;
-    --page-width: 60em;
-    --font-color: #151515;
-    --invert-font-color: #fff;
-    --primary-color: #1a95e0;
-    --secondary-color: #727578;
-    --error-color: #d20962;
-    --progress-bar-background: #727578;
-    --progress-bar-fill: #151515;
-    --code-bg-color: #e8eff2;
-    --input-style: solid;
-    --display-h1-decoration: none;
-    --block-background-color: var(--background-color);
-}
+
+/* this document is intentionally left empty.  for root configuration see terminal/css/terminal.css */

--- a/terminal/css/palettes/default.css
+++ b/terminal/css/palettes/default.css
@@ -1,11 +1,11 @@
-/*! terminal.css 0.7.2 | MIT License | github.com/Gioni06/terminal.css */
+/*! terminal.css 0.7.4 | MIT License | github.com/Gioni06/terminal.css */
 
 :root {
     --global-font-size: 15px;
     --global-line-height: 1.4em;
     --global-space: 10px;
-    --font-stack: Menlo, Monaco, Lucida Console, Liberation Mono, DejaVu Sans Mono, Bitstream Vera Sans Mono, Courier New, monospace, serif;
-    --mono-font-stack: Menlo, Monaco, Lucida Console, Liberation Mono, DejaVu Sans Mono, Bitstream Vera Sans Mono, Courier New, monospace, serif;
+    --font-stack: "Menlo", "Monaco", "Lucida Console", "Liberation Mono", "DejaVu Sans Mono", "Bitstream Vera Sans Mono", "Courier New", serif;
+    --mono-font-stack: "Menlo", "Monaco", "Lucida Console", "Liberation Mono", "DejaVu Sans Mono", "Bitstream Vera Sans Mono", "Courier New", serif;
     --background-color: #fff;
     --page-width: 60em;
     --font-color: #151515;
@@ -18,4 +18,5 @@
     --code-bg-color: #e8eff2;
     --input-style: solid;
     --display-h1-decoration: none;
+    --block-background-color: var(--background-color);
 }

--- a/terminal/css/palettes/default.css
+++ b/terminal/css/palettes/default.css
@@ -1,4 +1,4 @@
 /*! terminal.css 0.7.4 | MIT License | github.com/Gioni06/terminal.css */
 
 
-/* this document is intentionally left empty.  for root configuration see terminal/css/terminal.css */
+/* this document is intentionally left empty.  for root configuration, see terminal/css/terminal.css */

--- a/terminal/css/palettes/gruvbox_dark.css
+++ b/terminal/css/palettes/gruvbox_dark.css
@@ -9,14 +9,12 @@
     --gb-dm-bg2: #504945;
     --gb-dm-bg3: #665c54;
     --gb-dm-bg4: #7c6f64;
-
     /* Foreground */
     --gb-dm-fg0: #fbf1c7;
     --gb-dm-fg1: #ebdbb2;
     --gb-dm-fg2: #d5c4a1;
     --gb-dm-fg3: #bdae93;
     --gb-dm-fg4: #a89984;
-
     /* Colors */
     --gb-dm-dark-red: #cc241d;
     --gb-dm-dark-green: #98971a;
@@ -26,7 +24,6 @@
     --gb-dm-dark-aqua: #689d6a;
     --gb-dm-dark-orange: #d65d0e;
     --gb-dm-dark-gray: #928374;
-
     --gb-dm-light-red: #fb4934;
     --gb-dm-light-green: #b8bb26;
     --gb-dm-light-yellow: #fabd2f;
@@ -35,23 +32,22 @@
     --gb-dm-light-aqua: #8ec07c;
     --gb-dm-light-orange: #f38019;
     --gb-dm-light-gray: #a89984;
-
-    --global-font-size:        15px;
-    --global-line-height:      1.4em;
-    --global-space:            10px;
-    --font-stack:              Menlo, Monaco, Lucida Console, Liberation Mono, DejaVu Sans Mono, Bitstream Vera Sans Mono, Courier New, monospace, serif;
-    --mono-font-stack:         Menlo, Monaco, Lucida Console, Liberation Mono, DejaVu Sans Mono, Bitstream Vera Sans Mono, Courier New, monospace, serif;
-    --background-color:        var(--gb-dm-bg0);
-    --page-width:              60em;
-    --font-color:              var(--gb-dm-fg1);
-    --invert-font-color:       var(--gb-dm-bg0-hard);
-    --primary-color:           var(--gb-dm-light-yellow);
-    --secondary-color:         var(--gb-dm-fg3);
-    --tertiary-color:          var(--gb-dm-light-gray);
-    --error-color:             var(--gb-dm-light-red);
+    --global-font-size: 15px;
+    --global-line-height: 1.4em;
+    --global-space: 10px;
+    --font-stack: Menlo, Monaco, Lucida Console, Liberation Mono, DejaVu Sans Mono, Bitstream Vera Sans Mono, Courier New, monospace, serif;
+    --mono-font-stack: Menlo, Monaco, Lucida Console, Liberation Mono, DejaVu Sans Mono, Bitstream Vera Sans Mono, Courier New, monospace, serif;
+    --background-color: var(--gb-dm-bg0);
+    --page-width: 60em;
+    --font-color: var(--gb-dm-fg1);
+    --invert-font-color: var(--gb-dm-bg0-hard);
+    --primary-color: var(--gb-dm-light-yellow);
+    --secondary-color: var(--gb-dm-fg3);
+    --tertiary-color: var(--gb-dm-light-gray);
+    --error-color: var(--gb-dm-light-red);
     --progress-bar-background: var(--gb-dm-bg2);
-    --progress-bar-fill:       var(--gb-dm-fg2);
-    --code-bg-color:           var(--gb-dm-bg2);
-    --input-style:             solid;
-    --display-h1-decoration:   none;
+    --progress-bar-fill: var(--gb-dm-fg2);
+    --code-bg-color: var(--gb-dm-bg2);
+    --input-style: solid;
+    --display-h1-decoration: none;
 }

--- a/terminal/css/palettes/sans.css
+++ b/terminal/css/palettes/sans.css
@@ -1,20 +1,8 @@
-/*! sans.css 0.7.2 | MIT License | github.com/Gioni06/terminal.css */
+/*! sans.css 0.7.4 | MIT License | github.com/Gioni06/terminal.css */
 
 :root {
     --global-font-size: 15px;
     --global-line-height: 1.4em;
-    --global-space: 10px;
-    --font-stack: -apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol;
-    --background-color: #fff;
-    --page-width: 60em;
-    --font-color: #151515;
-    --invert-font-color: #fff;
-    --primary-color: #1a95e0;
-    --secondary-color: #727578;
-    --error-color: #d20962;
-    --progress-bar-background: #727578;
-    --progress-bar-fill: #151515;
-    --code-bg-color: #e8eff2;
+    --font-stack: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol;
     --input-style: solid;
-    --display-h1-decoration: none;        
 }

--- a/terminal/css/palettes/sans_dark.css
+++ b/terminal/css/palettes/sans_dark.css
@@ -1,22 +1,20 @@
-/*! sans_dark.css 0.7.2 | MIT License | github.com/Gioni06/terminal.css */
+/*! sans_dark.css 0.7.4 | MIT License | github.com/Gioni06/terminal.css */
 
 :root {
     --global-font-size: 15px;
     --global-line-height: 1.4em;
-    --global-space: 10px;
-    --font-stack: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica,
-      Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol;
+    --font-stack: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol;
     --background-color: #222225;
     --page-width: 60em;
     --font-color: #e8e9ed;
     --invert-font-color: #222225;
-    --primary-color: #62c4ff;
     --secondary-color: #a3abba;
     --tertiary-color: #a3abba;
+    --primary-color: #62c4ff;
     --error-color: #ff3c74;
     --progress-bar-background: #3f3f44;
     --progress-bar-fill: #62c4ff;
     --code-bg-color: #3f3f44;
     --input-style: solid;
     --display-h1-decoration: none;
-  }
+}

--- a/terminal/css/terminal.css
+++ b/terminal/css/terminal.css
@@ -1,18 +1,34 @@
-/*! terminal.css 0.7.2 | MIT License | github.com/Gioni06/terminal.css */
+/*! terminal.css 0.7.4 | MIT License | github.com/Gioni06/terminal.css */
+
+:root {
+    --global-font-size: 15px;
+    --global-line-height: 1.4em;
+    --global-space: 10px;
+    --font-stack: "Menlo", "Monaco", "Lucida Console", "Liberation Mono", "DejaVu Sans Mono", "Bitstream Vera Sans Mono", "Courier New", serif;
+    --mono-font-stack: "Menlo", "Monaco", "Lucida Console", "Liberation Mono", "DejaVu Sans Mono", "Bitstream Vera Sans Mono", "Courier New", serif;
+    --background-color: #fff;
+    --page-width: 60em;
+    --font-color: #151515;
+    --invert-font-color: #fff;
+    --primary-color: #1a95e0;
+    --secondary-color: #727578;
+    --error-color: #d20962;
+    --progress-bar-background: #727578;
+    --progress-bar-fill: #151515;
+    --code-bg-color: #e8eff2;
+    --input-style: solid;
+    --display-h1-decoration: none;
+    --block-background-color: var(--background-color);
+}
 
 * {
     box-sizing: border-box;
-    text-rendering: geometricPrecision
+    text-rendering: geometricprecision;
 }
 
-::-moz-selection {
+*::selection {
     background: var(--primary-color);
-    color: var(--invert-font-color)
-}
-
-::selection {
-    background: var(--primary-color);
-    color: var(--invert-font-color)
+    color: var(--invert-font-color);
 }
 
 body {
@@ -22,45 +38,44 @@ body {
     margin: 0;
     font-family: var(--font-stack);
     word-wrap: break-word;
-    background-color: var(--background-color)
+    background-color: var(--background-color);
 }
 
-.logo,
 h1,
 h2,
 h3,
 h4,
 h5,
-h6 {
-    line-height: var(--global-line-height)
+h6,
+.logo {
+    line-height: var(--global-line-height);
 }
 
 a {
     cursor: pointer;
     color: var(--primary-color);
-    text-decoration: none
+    text-decoration: none;
 }
 
 a:hover {
     background-color: var(--primary-color);
-    color: var(--invert-font-color)
+    color: var(--invert-font-color);
 }
 
 em {
     font-size: var(--global-font-size);
     font-style: italic;
     font-family: var(--font-stack);
-    color: var(--font-color)
+    color: var(--font-color);
 }
 
 blockquote,
 code,
 em,
 strong {
-    line-height: var(--global-line-height)
+    line-height: var(--global-line-height);
 }
 
-.logo,
 blockquote,
 code,
 footer,
@@ -75,31 +90,32 @@ li,
 ol,
 p,
 section,
-ul {
+ul,
+.logo {
     float: none;
     margin: 0;
-    padding: 0
+    padding: 0;
 }
 
-.logo,
 blockquote,
 h1,
 ol,
 p,
-ul {
+ul,
+.logo {
     margin-top: calc(var(--global-space) * 2);
-    margin-bottom: calc(var(--global-space) * 2)
+    margin-bottom: calc(var(--global-space) * 2);
 }
 
-.logo,
-h1 {
+h1,
+.logo {
     position: relative;
     display: inline-block;
     display: table-cell;
     padding: calc(var(--global-space) * 2) 0 calc(var(--global-space) * 2);
     margin: 0;
     overflow: hidden;
-    font-weight: 600
+    font-weight: 600;
 }
 
 h1::after {
@@ -107,12 +123,12 @@ h1::after {
     position: absolute;
     bottom: 5px;
     left: 0;
-    display: var(--display-h1-decoration)
+    display: var(--display-h1-decoration);
 }
 
-.logo+*,
-h1+* {
-    margin-top: 0
+h1+*,
+.logo+* {
+    margin-top: 0;
 }
 
 h2,
@@ -122,14 +138,14 @@ h5,
 h6 {
     position: relative;
     margin-bottom: var(--global-line-height);
-    font-weight: 600
+    font-weight: 600;
 }
 
 blockquote {
     position: relative;
     padding-left: calc(var(--global-space) * 2);
     padding-left: 2ch;
-    overflow: hidden
+    overflow: hidden;
 }
 
 blockquote::after {
@@ -139,24 +155,24 @@ blockquote::after {
     top: 0;
     left: 0;
     line-height: var(--global-line-height);
-    color: #9ca2ab
+    color: #9ca2ab;
 }
 
 code {
     font-weight: inherit;
     background-color: var(--code-bg-color);
-    font-family: var(--mono-font-stack)
+    font-family: var(--mono-font-stack);
 }
 
 code::after,
 code::before {
     content: "`";
-    display: inline
+    display: inline;
 }
 
 pre code::after,
 pre code::before {
-    content: ""
+    content: "";
 }
 
 pre {
@@ -164,13 +180,12 @@ pre {
     word-break: break-all;
     word-wrap: break-word;
     color: var(--secondary-color);
-    background-color: var(--background-color);
+    background-color: var(--block-background-color);
     border: 1px solid var(--secondary-color);
     padding: var(--global-space);
     white-space: pre-wrap;
     white-space: -moz-pre-wrap;
-    white-space: -pre-wrap;
-    white-space: -o-pre-wrap
+    white-space: -o-pre-wrap;
 }
 
 pre code {
@@ -179,69 +194,74 @@ pre code {
     margin: 0;
     display: inline-block;
     min-width: 100%;
-    font-family: var(--mono-font-stack)
+    font-family: var(--mono-font-stack);
+    background-color: var(--block-background-color);
 }
 
-.terminal .logo,
 .terminal blockquote,
-.terminal code,
 .terminal h1,
 .terminal h2,
 .terminal h3,
 .terminal h4,
 .terminal h5,
 .terminal h6,
-.terminal strong {
+.terminal strong,
+.terminal .logo {
     font-size: var(--global-font-size);
     font-style: normal;
     font-family: var(--font-stack);
-    color: var(--font-color)
+    color: var(--font-color);
+}
+
+.terminal code {
+    font-size: var(--global-font-size);
+    font-style: normal;
+    color: var(--font-color);
 }
 
 .terminal-prompt {
     position: relative;
-    white-space: nowrap
+    white-space: nowrap;
 }
 
 .terminal-prompt::before {
-    content: "> "
+    content: "> ";
 }
 
 .terminal-prompt::after {
     content: "";
-    -webkit-animation: cursor .8s infinite;
-    animation: cursor .8s infinite;
+    animation: cursor 800ms infinite;
     background: var(--primary-color);
     border-radius: 0;
     display: inline-block;
     height: 1em;
-    margin-left: .2em;
+    margin-left: 0.2em;
     width: 3px;
     bottom: -2px;
-    position: relative
+    position: relative;
 }
 
-@-webkit-keyframes cursor {
+@keyframes cursor {
     0% {
-        opacity: 0
+        opacity: 0;
     }
     50% {
-        opacity: 1
+        opacity: 1;
     }
-    to {
-        opacity: 0
+    100% {
+        opacity: 0;
     }
 }
 
 @keyframes cursor {
     0% {
-        opacity: 0
+        opacity: 0;
     }
     50% {
-        opacity: 1
+        opacity: 1;
     }
-    to {
-        opacity: 0
+    100% {
+        opacity: 0;
     }
 }
 
@@ -249,95 +269,95 @@ li,
 li>ul>li {
     position: relative;
     display: block;
-    padding-left: calc(var(--global-space) * 2)
+    padding-left: calc(var(--global-space) * 2);
 }
 
 nav>ul>li {
-    padding-left: 0
+    padding-left: 0;
 }
 
 li::after {
     position: absolute;
     top: 0;
-    left: 0
+    left: 0;
 }
 
 ul>li::after {
-    content: "-"
+    content: "-";
 }
 
 nav ul>li::after {
-    content: ""
+    content: "";
 }
 
 ol li::before {
     content: counters(item, ".") ". ";
-    counter-increment: item
+    counter-increment: item;
 }
 
 ol ol li::before {
     content: counters(item, ".") " ";
-    counter-increment: item
+    counter-increment: item;
 }
 
 .terminal-menu li::after,
 .terminal-menu li::before {
-    display: none
+    display: none;
 }
 
 ol {
-    counter-reset: item
+    counter-reset: item;
 }
 
 ol li:nth-child(n+10)::after {
-    left: -7px
+    left: -7px;
 }
 
 ol ol {
     margin-top: 0;
-    margin-bottom: 0
+    margin-bottom: 0;
 }
 
 .terminal-menu {
-    width: 100%
+    width: 100%;
 }
 
 .terminal-nav {
     display: flex;
     flex-direction: column;
-    align-items: flex-start
+    align-items: flex-start;
 }
 
 ul ul {
     margin-top: 0;
-    margin-bottom: 0
+    margin-bottom: 0;
 }
 
 .terminal-menu ul {
     list-style-type: none;
-    padding: 0!important;
+    padding: 0 !important;
     display: flex;
     flex-direction: column;
     width: 100%;
     flex-grow: 1;
     font-size: var(--global-font-size);
-    margin-top: 0
+    margin-top: 0;
 }
 
 .terminal-menu li {
     display: flex;
-    margin: 0 0 .5em 0;
-    padding: 0
+    margin: 0 0 0.5em;
+    padding: 0;
 }
 
 ol.terminal-toc li {
     border-bottom: 1px dotted var(--secondary-color);
     padding: 0;
-    margin-bottom: 15px
+    margin-bottom: 15px;
 }
 
 .terminal-menu li:last-child {
-    margin-bottom: 0
+    margin-bottom: 0;
 }
 
 ol.terminal-toc li a {
@@ -346,7 +366,7 @@ ol.terminal-toc li a {
     position: relative;
     top: 6px;
     text-align: left;
-    padding-right: 4px
+    padding-right: 4px;
 }
 
 .terminal-menu li a:not(.btn) {
@@ -354,16 +374,16 @@ ol.terminal-toc li a {
     display: block;
     width: 100%;
     border: none;
-    color: var(--secondary-color)
+    color: var(--secondary-color);
 }
 
 .terminal-menu li a.active {
-    color: var(--font-color)
+    color: var(--font-color);
 }
 
 .terminal-menu li a:hover {
-    background: 0 0;
-    color: inherit
+    background: none;
+    color: inherit;
 }
 
 ol.terminal-toc li::before {
@@ -373,12 +393,12 @@ ol.terminal-toc li::before {
     right: 0;
     background: var(--background-color);
     padding: 4px 0 4px 4px;
-    bottom: -8px
+    bottom: -8px;
 }
 
 ol.terminal-toc li a:hover {
     background: var(--primary-color);
-    color: var(--invert-font-color)
+    color: var(--invert-font-color);
 }
 
 hr {
@@ -386,44 +406,44 @@ hr {
     overflow: hidden;
     margin: calc(var(--global-space) * 4) 0;
     border: 0;
-    border-bottom: 1px dashed var(--secondary-color)
+    border-bottom: 1px dashed var(--secondary-color);
 }
 
 p {
     margin: 0 0 var(--global-line-height);
-    color: var(--global-font-color)
+    color: var(--font-color);
 }
 
 .container {
-    max-width: var(--page-width)
+    max-width: var(--page-width);
 }
 
 .container,
 .container-fluid {
     margin: 0 auto;
-    padding: 0 calc(var(--global-space) * 2)
+    padding: 0 calc(var(--global-space) * 2);
 }
 
 img {
-    width: 100%
+    width: 100%;
 }
 
 .progress-bar {
     height: 8px;
     background-color: var(--progress-bar-background);
-    margin: 12px 0
+    margin: 12px 0;
 }
 
 .progress-bar.progress-bar-show-percent {
-    margin-top: 38px
+    margin-top: 38px;
 }
 
 .progress-bar-filled {
     background-color: var(--progress-bar-fill);
     height: 100%;
-    transition: width .3s ease;
+    transition: width 0.3s ease;
     position: relative;
-    width: 0
+    width: 0;
 }
 
 .progress-bar-filled::before {
@@ -432,7 +452,7 @@ img {
     border-top-color: var(--progress-bar-fill);
     position: absolute;
     top: -12px;
-    right: -6px
+    right: -6px;
 }
 
 .progress-bar-filled::after {
@@ -445,15 +465,15 @@ img {
     border: 6px solid transparent;
     top: -38px;
     right: 0;
-    transform: translateX(50%)
+    transform: translateX(50%);
 }
 
-.progress-bar-no-arrow>.progress-bar-filled::after,
-.progress-bar-no-arrow>.progress-bar-filled::before {
+.progress-bar-no-arrow>.progress-bar-filled::before,
+.progress-bar-no-arrow>.progress-bar-filled::after {
     content: "";
     display: none;
     visibility: hidden;
-    opacity: 0
+    opacity: 0;
 }
 
 table {
@@ -461,7 +481,7 @@ table {
     border-collapse: collapse;
     margin: var(--global-line-height) 0;
     color: var(--font-color);
-    font-size: var(--global-font-size)
+    font-size: var(--global-font-size);
 }
 
 table td,
@@ -469,113 +489,89 @@ table th {
     vertical-align: top;
     border: 1px solid var(--font-color);
     line-height: var(--global-line-height);
-    padding: calc(var(--global-space)/ 2);
-    font-size: 1em
+    padding: calc(var(--global-space) / 2);
+    font-size: 1em;
 }
 
 table thead th {
-    font-size: 1em
+    font-size: 1em;
 }
 
 table tfoot tr th {
-    font-weight: 500
+    font-weight: 500;
 }
 
 table caption {
     font-size: 1em;
-    margin: 0 0 1em 0
+    margin: 0 0 1em;
 }
 
 table tbody td:first-child {
     font-weight: 700;
-    color: var(--secondary-color)
+    color: var(--secondary-color);
 }
 
 .form {
-    width: 100%
+    width: 100%;
 }
 
 fieldset {
     border: 1px solid var(--font-color);
-    padding: 1em
+    padding: 1em;
 }
 
 label {
     font-size: 1em;
-    color: var(--font-color)
+    color: var(--font-color);
 }
 
-input[type=email],
-input[type=number],
-input[type=password],
-input[type=search],
-input[type=text] {
+input[type="email"],
+input[type="text"],
+input[type="number"],
+input[type="password"],
+input[type="search"] {
     border: 1px var(--input-style) var(--font-color);
     width: 100%;
-    padding: .7em .5em;
+    padding: 0.7em 0.5em;
     font-size: 1em;
     font-family: var(--font-stack);
-    -webkit-appearance: none;
-    border-radius: 0
+    appearance: none;
+    border-radius: 0;
 }
 
-input[type=email]:active,
-input[type=email]:focus,
-input[type=number]:active,
-input[type=number]:focus,
-input[type=password]:active,
-input[type=password]:focus,
-input[type=search]:active,
-input[type=search]:focus,
-input[type=text]:active,
-input[type=text]:focus {
-    outline: 0;
-    -webkit-appearance: none;
-    border: 1px solid var(--font-color)
+input[type="email"]:active,
+input[type="text"]:active,
+input[type="number"]:active,
+input[type="password"]:active,
+input[type="search"]:active,
+input[type="email"]:focus,
+input[type="text"]:focus,
+input[type="number"]:focus,
+input[type="password"]:focus,
+input[type="search"]:focus {
+    outline: none;
+    appearance: none;
+    border: 1px solid var(--font-color);
 }
 
-input[type=email]:not(:placeholder-shown):invalid,
-input[type=number]:not(:placeholder-shown):invalid,
-input[type=password]:not(:placeholder-shown):invalid,
-input[type=search]:not(:placeholder-shown):invalid,
-input[type=text]:not(:placeholder-shown):invalid {
-    border-color: var(--error-color)
+input[type="text"]:not(:placeholder-shown):invalid,
+input[type="email"]:not(:placeholder-shown):invalid,
+input[type="password"]:not(:placeholder-shown):invalid,
+input[type="search"]:not(:placeholder-shown):invalid,
+input[type="number"]:not(:placeholder-shown):invalid {
+    border-color: var(--error-color);
 }
 
 input,
 textarea {
     color: var(--font-color);
-    background-color: var(--background-color)
-}
-
-input::-webkit-input-placeholder,
-textarea::-webkit-input-placeholder {
-    color: var(--secondary-color)!important;
-    opacity: 1
-}
-
-input::-moz-placeholder,
-textarea::-moz-placeholder {
-    color: var(--secondary-color)!important;
-    opacity: 1
-}
-
-input:-ms-input-placeholder,
-textarea:-ms-input-placeholder {
-    color: var(--secondary-color)!important;
-    opacity: 1
-}
-
-input::-ms-input-placeholder,
-textarea::-ms-input-placeholder {
-    color: var(--secondary-color)!important;
-    opacity: 1
+    background-color: var(--background-color);
 }
 
 input::placeholder,
 textarea::placeholder {
-    color: var(--secondary-color)!important;
-    opacity: 1
+    color: var(--secondary-color) !important;
+    opacity: 1;
 }
 
 textarea {
@@ -583,189 +579,187 @@ textarea {
     width: 100%;
     resize: none;
     border: 1px var(--input-style) var(--font-color);
-    padding: .5em;
+    padding: 0.5em;
     font-size: 1em;
     font-family: var(--font-stack);
-    -webkit-appearance: none;
-    border-radius: 0
+    appearance: none;
+    border-radius: 0;
 }
 
 textarea:focus {
-    outline: 0;
-    -webkit-appearance: none;
-    border: 1px solid var(--font-color)
+    outline: none;
+    appearance: none;
+    border: 1px solid var(--font-color);
 }
 
 textarea:not(:placeholder-shown):invalid {
-    border-color: var(--error-color)
+    border-color: var(--error-color);
 }
 
 input:-webkit-autofill,
-input:-webkit-autofill:focus textarea:-webkit-autofill,
 input:-webkit-autofill:hover,
+input:-webkit-autofill:focus textarea:-webkit-autofill,
+textarea:-webkit-autofill:hover textarea:-webkit-autofill:focus,
 select:-webkit-autofill,
-select:-webkit-autofill:focus,
 select:-webkit-autofill:hover,
-textarea:-webkit-autofill:hover textarea:-webkit-autofill:focus {
+select:-webkit-autofill:focus {
     border: 1px solid var(--font-color);
     -webkit-text-fill-color: var(--font-color);
-    box-shadow: 0 0 0 1000px var(--invert-font-color) inset;
-    -webkit-box-shadow: 0 0 0 1000px var(--invert-font-color) inset;
-    transition: background-color 5000s ease-in-out 0s
+    box-shadow: 0 0 0 1e3pxx var(--invert-font-color) inset;
+    transition: background-color 5e3ss ease-in-out 0s;
 }
 
 .form-group {
     margin-bottom: var(--global-line-height);
-    overflow: auto
+    overflow: auto;
 }
 
 .btn {
     border-style: solid;
     border-width: 1px;
     display: inline-flex;
+    -ms-flex-align: center;
     align-items: center;
+    -ms-flex-pack: center;
     justify-content: center;
     cursor: pointer;
-    outline: 0;
-    padding: .65em 2em;
+    outline: none;
+    padding: 0.65em 2em;
     font-size: 1em;
     font-family: inherit;
-    -webkit-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
     user-select: none;
     position: relative;
-    z-index: 1
+    z-index: 1;
 }
 
 .btn:active {
-    box-shadow: none
+    box-shadow: none;
 }
 
 .btn.btn-ghost {
     border-color: var(--font-color);
     color: var(--font-color);
-    background-color: transparent
+    background-color: transparent;
 }
 
 .btn.btn-ghost:focus,
 .btn.btn-ghost:hover {
     border-color: var(--tertiary-color);
     color: var(--tertiary-color);
-    z-index: 2
+    z-index: 2;
 }
 
 .btn.btn-ghost:hover {
-    background-color: transparent
+    background-color: transparent;
 }
 
 .btn-block {
     width: 100%;
-    display: flex
+    display: flex;
 }
 
 .btn-default {
     background-color: var(--font-color);
     border-color: var(--invert-font-color);
-    color: var(--invert-font-color)
+    color: var(--invert-font-color);
 }
 
-.btn-default:focus:not(.btn-ghost),
-.btn-default:hover {
+.btn-default:hover,
+.btn-default:focus:not(.btn-ghost) {
     background-color: var(--secondary-color);
-    color: var(--invert-font-color)
+    color: var(--invert-font-color);
 }
 
 .btn-default.btn-ghost:focus,
 .btn-default.btn-ghost:hover {
     border-color: var(--secondary-color);
     color: var(--secondary-color);
-    z-index: 2
+    z-index: 2;
 }
 
 .btn-error {
     color: var(--invert-font-color);
     background-color: var(--error-color);
-    border: 1px solid var(--error-color)
+    border: 1px solid var(--error-color);
 }
 
-.btn-error:focus:not(.btn-ghost),
-.btn-error:hover {
+.btn-error:hover,
+.btn-error:focus:not(.btn-ghost) {
     background-color: var(--error-color);
-    border-color: var(--error-color)
+    border-color: var(--error-color);
 }
 
 .btn-error.btn-ghost {
     border-color: var(--error-color);
-    color: var(--error-color)
+    color: var(--error-color);
 }
 
 .btn-error.btn-ghost:focus,
 .btn-error.btn-ghost:hover {
     border-color: var(--error-color);
     color: var(--error-color);
-    z-index: 2
+    z-index: 2;
 }
 
 .btn-primary {
     color: var(--invert-font-color);
     background-color: var(--primary-color);
-    border: 1px solid var(--primary-color)
+    border: 1px solid var(--primary-color);
 }
 
-.btn-primary:focus:not(.btn-ghost),
-.btn-primary:hover {
+.btn-primary:hover,
+.btn-primary:focus:not(.btn-ghost) {
     background-color: var(--primary-color);
-    border-color: var(--primary-color)
+    border-color: var(--primary-color);
 }
 
 .btn-primary.btn-ghost {
     border-color: var(--primary-color);
-    color: var(--primary-color)
+    color: var(--primary-color);
 }
 
 .btn-primary.btn-ghost:focus,
 .btn-primary.btn-ghost:hover {
     border-color: var(--primary-color);
     color: var(--primary-color);
-    z-index: 2
+    z-index: 2;
 }
 
 .btn-small {
-    padding: .5em 1.3em!important;
-    font-size: .9em!important
+    padding: 0.5em 1.3em !important;
+    font-size: 0.9em !important;
 }
 
 .btn-group {
-    overflow: auto
+    overflow: auto;
 }
 
 .btn-group .btn {
-    float: left
+    float: left;
 }
 
 .btn-group .btn-ghost:not(:first-child) {
-    margin-left: -1px
+    margin-left: -1px;
 }
 
 .terminal-card {
-    border: 1px solid var(--secondary-color)
+    border: 1px solid var(--secondary-color);
 }
 
 .terminal-card>header {
     color: var(--invert-font-color);
     text-align: center;
     background-color: var(--secondary-color);
-    padding: .5em 0
+    padding: 0.5em 0;
 }
 
 .terminal-card>div:first-of-type {
-    padding: var(--global-space)
+    padding: var(--global-space);
 }
 
 .terminal-timeline {
     position: relative;
-    padding-left: 70px
+    padding-left: 70px;
 }
 
 .terminal-timeline::before {
@@ -776,11 +770,11 @@ textarea:-webkit-autofill:hover textarea:-webkit-autofill:focus {
     left: 35px;
     width: 2px;
     height: 100%;
-    z-index: 400
+    z-index: 400;
 }
 
 .terminal-timeline .terminal-card {
-    margin-bottom: 25px
+    margin-bottom: 25px;
 }
 
 .terminal-timeline .terminal-card::before {
@@ -793,93 +787,92 @@ textarea:-webkit-autofill:hover textarea:-webkit-autofill:focus {
     left: 26px;
     width: 15px;
     height: 15px;
-    z-index: 400
+    z-index: 400;
 }
 
 .terminal-alert {
     color: var(--font-color);
     padding: 1em;
     border: 1px solid var(--font-color);
-    margin-bottom: var(--global-space)
+    margin-bottom: var(--global-space);
 }
 
 .terminal-alert-error {
     color: var(--error-color);
-    border-color: var(--error-color)
+    border-color: var(--error-color);
 }
 
 .terminal-alert-primary {
     color: var(--primary-color);
-    border-color: var(--primary-color)
+    border-color: var(--primary-color);
 }
 
-@media screen and (max-width:960px) {
+@media screen and (width <=960px) {
     label {
         display: block;
-        width: 100%
+        width: 100%;
     }
     pre::-webkit-scrollbar {
-        height: 3px
+        height: 3px;
     }
 }
 
-@media screen and (max-width:480px) {
+@media screen and (width <=480px) {
     form {
-        width: 100%
+        width: 100%;
     }
 }
 
-@media only screen and (min-width:30em) {
+@media only screen and (width >=30em) {
     .terminal-nav {
         flex-direction: row;
-        align-items: center
+        align-items: center;
     }
     .terminal-menu ul {
         flex-direction: row;
-        justify-items: flex-end;
-        align-items: center;
+        place-items: center flex-end;
         justify-content: flex-end;
-        margin-top: calc(var(--global-space) * 2)
+        margin-top: calc(var(--global-space) * 2);
     }
     .terminal-menu li {
         margin: 0;
-        margin-right: 2em
+        margin-right: 2em;
     }
     .terminal-menu li:last-child {
-        margin-right: 0
+        margin-right: 0;
     }
 }
 
 .terminal-media:not(:last-child) {
-    margin-bottom: 1.25rem
+    margin-bottom: 1.25rem;
 }
 
 .terminal-media-left {
-    padding-right: var(--global-space)
+    padding-right: var(--global-space);
 }
 
 .terminal-media-left,
 .terminal-media-right {
     display: table-cell;
-    vertical-align: top
+    vertical-align: top;
 }
 
 .terminal-media-right {
-    padding-left: var(--global-space)
+    padding-left: var(--global-space);
 }
 
 .terminal-media-body {
     display: table-cell;
-    vertical-align: top
+    vertical-align: top;
 }
 
 .terminal-media-heading {
     font-size: 1em;
-    font-weight: 700
+    font-weight: 700;
 }
 
 .terminal-media-content {
-    margin-top: .3rem
+    margin-top: 0.3rem;
 }
 
 .terminal-placeholder {
@@ -887,97 +880,101 @@ textarea:-webkit-autofill:hover textarea:-webkit-autofill:focus {
     text-align: center;
     color: var(--font-color);
     font-size: 1rem;
-    border: 1px solid var(--secondary-color)
+    border: 1px solid var(--secondary-color);
 }
 
 figure>img {
-    padding: 0
+    padding: 0;
 }
 
 .terminal-avatarholder {
     width: calc(var(--global-space) * 5);
-    height: calc(var(--global-space) * 5)
+    height: calc(var(--global-space) * 5);
 }
 
 .terminal-avatarholder img {
-    padding: 0
+    padding: 0;
 }
 
 figure {
-    margin: 0
+    margin: 0;
 }
 
 figure>figcaption {
     color: var(--secondary-color);
-    text-align: center
+    text-align: center;
 }
 
 .hljs {
     display: block;
     overflow-x: auto;
-    padding: .5em;
+    padding: 0.5em;
     background: var(--block-background-color);
-    color: var(--font-color)
+    color: var(--font-color);
 }
 
 .hljs-comment,
 .hljs-quote {
-    color: var(--secondary-color)
+    color: var(--secondary-color);
 }
 
 .hljs-variable {
-    color: var(--font-color)
+    color: var(--font-color);
 }
 
-.hljs-built_in,
+
+/* stylelint-disable */
+
 .hljs-keyword,
-.hljs-name,
 .hljs-selector-tag,
+.hljs-built_in,
+.hljs-name,
 .hljs-tag {
-    color: var(--primary-color)
+    /* stylelint-enable */
+    color: var(--primary-color);
 }
 
-.hljs-addition,
+.hljs-string,
+.hljs-title,
+.hljs-section,
 .hljs-attribute,
 .hljs-literal,
-.hljs-section,
-.hljs-string,
 .hljs-template-tag,
 .hljs-template-variable,
-.hljs-title,
-.hljs-type {
-    color: var(--secondary-color)
+.hljs-type,
+.hljs-addition {
+    color: var(--secondary-color);
 }
 
 .hljs-string {
-    color: var(--secondary-color)
+    color: var(--secondary-color);
 }
 
 .hljs-deletion,
-.hljs-meta,
 .hljs-selector-attr,
-.hljs-selector-pseudo {
-    color: var(--primary-color)
+.hljs-selector-pseudo,
+.hljs-meta {
+    color: var(--primary-color);
 }
 
 .hljs-doctag {
-    color: var(--secondary-color)
+    color: var(--secondary-color);
 }
 
 .hljs-attr {
-    color: var(--primary-color)
+    color: var(--primary-color);
 }
 
+.hljs-symbol,
 .hljs-bullet,
-.hljs-link,
-.hljs-symbol {
-    color: var(--primary-color)
+.hljs-link {
+    color: var(--primary-color);
 }
 
 .hljs-emphasis {
-    font-style: italic
+    font-style: italic;
 }
 
 .hljs-strong {
-    font-weight: 700
+    font-weight: bold;
 }

--- a/terminal/css/terminal.css
+++ b/terminal/css/terminal.css
@@ -28,12 +28,7 @@
 
 *::selection {
     background: var(--primary-color);
-    color: var(--invert-font-color)
-}
-
-::selection {
-    background: var(--primary-color);
-    color: var(--invert-font-color)
+    color: var(--invert-font-color);
 }
 
 body {
@@ -43,7 +38,6 @@ body {
     margin: 0;
     font-family: var(--font-stack);
     word-wrap: break-word;
-    background-color: var(--background-color);
     background-color: var(--background-color);
 }
 
@@ -145,7 +139,6 @@ h6 {
     position: relative;
     margin-bottom: var(--global-line-height);
     font-weight: 600;
-    font-weight: 600;
 }
 
 blockquote {
@@ -229,11 +222,9 @@ pre code {
 .terminal-prompt {
     position: relative;
     white-space: nowrap;
-    white-space: nowrap;
 }
 
 .terminal-prompt::before {
-    content: "> ";
     content: "> ";
 }
 
@@ -248,16 +239,13 @@ pre code {
     width: 3px;
     bottom: -2px;
     position: relative;
-    position: relative;
 }
 
 @keyframes cursor {
     0% {
         opacity: 0;
-        opacity: 0;
     }
     50% {
-        opacity: 1;
         opacity: 1;
     }
     100% {
@@ -268,10 +256,8 @@ pre code {
 @keyframes cursor {
     0% {
         opacity: 0;
-        opacity: 0;
     }
     50% {
-        opacity: 1;
         opacity: 1;
     }
     100% {
@@ -284,11 +270,9 @@ li>ul>li {
     position: relative;
     display: block;
     padding-left: calc(var(--global-space) * 2);
-    padding-left: calc(var(--global-space) * 2);
 }
 
 nav>ul>li {
-    padding-left: 0;
     padding-left: 0;
 }
 
@@ -358,7 +342,6 @@ ul ul {
     flex-grow: 1;
     font-size: var(--global-font-size);
     margin-top: 0;
-    margin-top: 0;
 }
 
 .terminal-menu li {
@@ -423,7 +406,6 @@ hr {
     overflow: hidden;
     margin: calc(var(--global-space) * 4) 0;
     border: 0;
-    border-bottom: 1px dashed var(--secondary-color);
     border-bottom: 1px dashed var(--secondary-color);
 }
 
@@ -491,7 +473,6 @@ img {
     content: "";
     display: none;
     visibility: hidden;
-    opacity: 0;
     opacity: 0;
 }
 
@@ -591,8 +572,6 @@ input::placeholder,
 textarea::placeholder {
     color: var(--secondary-color) !important;
     opacity: 1;
-    color: var(--secondary-color) !important;
-    opacity: 1;
 }
 
 textarea {
@@ -615,7 +594,6 @@ textarea:focus {
 
 textarea:not(:placeholder-shown):invalid {
     border-color: var(--error-color);
-    border-color: var(--error-color);
 }
 
 input:-webkit-autofill,
@@ -633,7 +611,6 @@ select:-webkit-autofill:focus {
 
 .form-group {
     margin-bottom: var(--global-line-height);
-    overflow: auto;
     overflow: auto;
 }
 
@@ -653,7 +630,6 @@ select:-webkit-autofill:focus {
     user-select: none;
     position: relative;
     z-index: 1;
-    z-index: 1;
 }
 
 .btn:active {
@@ -671,17 +647,14 @@ select:-webkit-autofill:focus {
     border-color: var(--tertiary-color);
     color: var(--tertiary-color);
     z-index: 2;
-    z-index: 2;
 }
 
 .btn.btn-ghost:hover {
-    background-color: transparent;
     background-color: transparent;
 }
 
 .btn-block {
     width: 100%;
-    display: flex;
     display: flex;
 }
 
@@ -871,11 +844,11 @@ select:-webkit-autofill:focus {
 }
 
 .terminal-media:not(:last-child) {
-    margin-bottom: 1.25rem
+    margin-bottom: 1.25rem;
 }
 
 .terminal-media-left {
-    padding-right: var(--global-space)
+    padding-right: var(--global-space);
 }
 
 .terminal-media-left,
@@ -975,7 +948,6 @@ figure>figcaption {
 
 .hljs-string {
     color: var(--secondary-color);
-    color: var(--secondary-color);
 }
 
 .hljs-deletion,
@@ -990,7 +962,6 @@ figure>figcaption {
 }
 
 .hljs-attr {
-    color: var(--primary-color);
     color: var(--primary-color);
 }
 

--- a/terminal/css/theme.css
+++ b/terminal/css/theme.css
@@ -70,6 +70,13 @@ code::before {
 }
 
 
+/* use the `code-bg-color` for `code` blocks */
+
+pre code {
+    background-color: var(--code-bg-color);
+}
+
+
 /*! terminal.css | MIT License |  https://github.com/Gioni06/terminal.css/pull/36 */
 
 blockquote>*:last-child {

--- a/terminal/css/theme.css
+++ b/terminal/css/theme.css
@@ -1,7 +1,7 @@
 /*! Terminal for MkDocs | MIT License | github.com/ntno/mkdocs-terminal */
 
 
-/*! terminal.css 0.7.2  | MIT License | github.com/Gioni06/terminal.css */
+/*! terminal.css 0.7.4  | MIT License | github.com/Gioni06/terminal.css */
 
 body {
     padding-top: 50px;
@@ -52,6 +52,13 @@ a.btn {
 }
 
 
+/* set figcaption paragraph text to the secondary color.  this occurs when using markdown inside the figcaption */
+
+figure>figcaption>p {
+    color: var(--secondary-color);
+}
+
+
 /* ***************************************************************** */
 
 
@@ -77,7 +84,7 @@ pre code {
 }
 
 
-/*! terminal.css | MIT License |  https://github.com/Gioni06/terminal.css/pull/36 */
+/* fix trailing `>` symbol on blockquotes - https://github.com/Gioni06/terminal.css/pull/36 */
 
 blockquote>*:last-child {
     margin-bottom: 0;

--- a/terminal/theme_version.html
+++ b/terminal/theme_version.html
@@ -1,1 +1,1 @@
-<meta name="generator" content="mkdocs-{{ mkdocs_version }}, mkdocs-terminal-4.4.0">
+<meta name="generator" content="mkdocs-{{ mkdocs_version }}, mkdocs-terminal-4.5.0">


### PR DESCRIPTION
# point to terminal.css version 0.7.4 (currently at 0.7.2)
would make progress on #144 

### Description

the "Terminal for MkDocs" theme is currently behind the terminal.css upstream.  this change updates `terminal/css/terminal.css` to point to version 0.7.4 and makes a few updates to `terminal/css/theme.css` to maintain current behavior.

### Changes

- pulls in [terminal.css version 0.7.4](https://github.com/Gioni06/terminal.css/releases/tag/v0.7.4)
  - includes a fix to the `<p>` font color which should be set to `font-color` and not `global-font-color`
- specifies that `<p>` inside a `<figcaption>` should use `secondary-color`.  

### Testing

spun up local documentation server in Firefox and spot checked

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in [mkdocs-terminal/documentation](https://github.com/ntno/mkdocs-terminal/tree/main/documentation/docs)
- [x] All active GitHub checks for tests, formatting, and security are passing

