### PR TITLE
Fix CSS formatting

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mkdocs-terminal",
-    "version": "4.4.0",
+    "version": "4.4.1",
     "description": "Terminal.css theme for MkDocs",
     "keywords": [
         "mkdocs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mkdocs-terminal",
-    "version": "4.4.1",
+    "version": "4.4.2",
     "description": "Terminal.css theme for MkDocs",
     "keywords": [
         "mkdocs",

--- a/terminal/css/normalize.css
+++ b/terminal/css/normalize.css
@@ -1,349 +1,419 @@
 /*! normalize.css v8.0.1 | MIT License | github.com/necolas/normalize.css */
 
+
 /* Document
    ========================================================================== */
+
 
 /**
  * 1. Correct the line height in all browsers.
  * 2. Prevent adjustments of font size after orientation changes in iOS.
  */
 
- html {
-    line-height: 1.15; /* 1 */
-    -webkit-text-size-adjust: 100%; /* 2 */
-  }
-  
-  /* Sections
+html {
+    line-height: 1.15;
+    /* 1 */
+    -webkit-text-size-adjust: 100%;
+    /* 2 */
+}
+
+
+/* Sections
      ========================================================================== */
-  
-  /**
+
+
+/**
    * Remove the margin in all browsers.
    */
-  
-  body {
+
+body {
     margin: 0;
-  }
-  
-  /**
+}
+
+
+/**
    * Render the `main` element consistently in IE.
    */
-  
-  main {
+
+main {
     display: block;
-  }
-  
-  /**
+}
+
+
+/**
    * Correct the font size and margin on `h1` elements within `section` and
    * `article` contexts in Chrome, Firefox, and Safari.
    */
-  
-  h1 {
+
+h1 {
     font-size: 2em;
     margin: 0.67em 0;
-  }
-  
-  /* Grouping content
+}
+
+
+/* Grouping content
      ========================================================================== */
-  
-  /**
+
+
+/**
    * 1. Add the correct box sizing in Firefox.
    * 2. Show the overflow in Edge and IE.
    */
-  
-  hr {
-    box-sizing: content-box; /* 1 */
-    height: 0; /* 1 */
-    overflow: visible; /* 2 */
-  }
-  
-  /**
+
+hr {
+    box-sizing: content-box;
+    /* 1 */
+    height: 0;
+    /* 1 */
+    overflow: visible;
+    /* 2 */
+}
+
+
+/**
    * 1. Correct the inheritance and scaling of font size in all browsers.
    * 2. Correct the odd `em` font sizing in all browsers.
    */
-  
-  pre {
-    font-family: monospace, monospace; /* 1 */
-    font-size: 1em; /* 2 */
-  }
-  
-  /* Text-level semantics
+
+pre {
+    font-family: monospace, monospace;
+    /* 1 */
+    font-size: 1em;
+    /* 2 */
+}
+
+
+/* Text-level semantics
      ========================================================================== */
-  
-  /**
+
+
+/**
    * Remove the gray background on active links in IE 10.
    */
-  
-  a {
+
+a {
     background-color: transparent;
-  }
-  
-  /**
+}
+
+
+/**
    * 1. Remove the bottom border in Chrome 57-
    * 2. Add the correct text decoration in Chrome, Edge, IE, Opera, and Safari.
    */
-  
-  abbr[title] {
-    border-bottom: none; /* 1 */
-    text-decoration: underline; /* 2 */
-    text-decoration: underline dotted; /* 2 */
-  }
-  
-  /**
+
+abbr[title] {
+    border-bottom: none;
+    /* 1 */
+    text-decoration: underline;
+    /* 2 */
+    text-decoration: underline dotted;
+    /* 2 */
+}
+
+
+/**
    * Add the correct font weight in Chrome, Edge, and Safari.
    */
-  
-  b,
-  strong {
+
+b,
+strong {
     font-weight: bolder;
-  }
-  
-  /**
+}
+
+
+/**
    * 1. Correct the inheritance and scaling of font size in all browsers.
    * 2. Correct the odd `em` font sizing in all browsers.
    */
-  
-  code,
-  kbd,
-  samp {
-    font-family: monospace, monospace; /* 1 */
-    font-size: 1em; /* 2 */
-  }
-  
-  /**
+
+code,
+kbd,
+samp {
+    font-family: monospace, monospace;
+    /* 1 */
+    font-size: 1em;
+    /* 2 */
+}
+
+
+/**
    * Add the correct font size in all browsers.
    */
-  
-  small {
+
+small {
     font-size: 80%;
-  }
-  
-  /**
+}
+
+
+/**
    * Prevent `sub` and `sup` elements from affecting the line height in
    * all browsers.
    */
-  
-  sub,
-  sup {
+
+sub,
+sup {
     font-size: 75%;
     line-height: 0;
     position: relative;
     vertical-align: baseline;
-  }
-  
-  sub {
+}
+
+sub {
     bottom: -0.25em;
-  }
-  
-  sup {
+}
+
+sup {
     top: -0.5em;
-  }
-  
-  /* Embedded content
+}
+
+
+/* Embedded content
      ========================================================================== */
-  
-  /**
+
+
+/**
    * Remove the border on images inside links in IE 10.
    */
-  
-  img {
+
+img {
     border-style: none;
-  }
-  
-  /* Forms
+}
+
+
+/* Forms
      ========================================================================== */
-  
-  /**
+
+
+/**
    * 1. Change the font styles in all browsers.
    * 2. Remove the margin in Firefox and Safari.
    */
-  
-  button,
-  input,
-  optgroup,
-  select,
-  textarea {
-    font-family: inherit; /* 1 */
-    font-size: 100%; /* 1 */
-    line-height: 1.15; /* 1 */
-    margin: 0; /* 2 */
-  }
-  
-  /**
+
+button,
+input,
+optgroup,
+select,
+textarea {
+    font-family: inherit;
+    /* 1 */
+    font-size: 100%;
+    /* 1 */
+    line-height: 1.15;
+    /* 1 */
+    margin: 0;
+    /* 2 */
+}
+
+
+/**
    * Show the overflow in IE.
    * 1. Show the overflow in Edge.
    */
-  
-  button,
-  input { /* 1 */
+
+button,
+input {
+    /* 1 */
     overflow: visible;
-  }
-  
-  /**
+}
+
+
+/**
    * Remove the inheritance of text transform in Edge, Firefox, and IE.
    * 1. Remove the inheritance of text transform in Firefox.
    */
-  
-  button,
-  select { /* 1 */
+
+button,
+select {
+    /* 1 */
     text-transform: none;
-  }
-  
-  /**
+}
+
+
+/**
    * Correct the inability to style clickable types in iOS and Safari.
    */
-  
-  button,
-  [type="button"],
-  [type="reset"],
-  [type="submit"] {
+
+button,
+[type="button"],
+[type="reset"],
+[type="submit"] {
     -webkit-appearance: button;
-  }
-  
-  /**
+}
+
+
+/**
    * Remove the inner border and padding in Firefox.
    */
-  
-  button::-moz-focus-inner,
-  [type="button"]::-moz-focus-inner,
-  [type="reset"]::-moz-focus-inner,
-  [type="submit"]::-moz-focus-inner {
+
+button::-moz-focus-inner,
+[type="button"]::-moz-focus-inner,
+[type="reset"]::-moz-focus-inner,
+[type="submit"]::-moz-focus-inner {
     border-style: none;
     padding: 0;
-  }
-  
-  /**
+}
+
+
+/**
    * Restore the focus styles unset by the previous rule.
    */
-  
-  button:-moz-focusring,
-  [type="button"]:-moz-focusring,
-  [type="reset"]:-moz-focusring,
-  [type="submit"]:-moz-focusring {
+
+button:-moz-focusring,
+[type="button"]:-moz-focusring,
+[type="reset"]:-moz-focusring,
+[type="submit"]:-moz-focusring {
     outline: 1px dotted ButtonText;
-  }
-  
-  /**
+}
+
+
+/**
    * Correct the padding in Firefox.
    */
-  
-  fieldset {
+
+fieldset {
     padding: 0.35em 0.75em 0.625em;
-  }
-  
-  /**
+}
+
+
+/**
    * 1. Correct the text wrapping in Edge and IE.
    * 2. Correct the color inheritance from `fieldset` elements in IE.
    * 3. Remove the padding so developers are not caught out when they zero out
    *    `fieldset` elements in all browsers.
    */
-  
-  legend {
-    box-sizing: border-box; /* 1 */
-    color: inherit; /* 2 */
-    display: table; /* 1 */
-    max-width: 100%; /* 1 */
-    padding: 0; /* 3 */
-    white-space: normal; /* 1 */
-  }
-  
-  /**
+
+legend {
+    box-sizing: border-box;
+    /* 1 */
+    color: inherit;
+    /* 2 */
+    display: table;
+    /* 1 */
+    max-width: 100%;
+    /* 1 */
+    padding: 0;
+    /* 3 */
+    white-space: normal;
+    /* 1 */
+}
+
+
+/**
    * Add the correct vertical alignment in Chrome, Firefox, and Opera.
    */
-  
-  progress {
+
+progress {
     vertical-align: baseline;
-  }
-  
-  /**
+}
+
+
+/**
    * Remove the default vertical scrollbar in IE 10+.
    */
-  
-  textarea {
+
+textarea {
     overflow: auto;
-  }
-  
-  /**
+}
+
+
+/**
    * 1. Add the correct box sizing in IE 10.
    * 2. Remove the padding in IE 10.
    */
-  
-  [type="checkbox"],
-  [type="radio"] {
-    box-sizing: border-box; /* 1 */
-    padding: 0; /* 2 */
-  }
-  
-  /**
+
+[type="checkbox"],
+[type="radio"] {
+    box-sizing: border-box;
+    /* 1 */
+    padding: 0;
+    /* 2 */
+}
+
+
+/**
    * Correct the cursor style of increment and decrement buttons in Chrome.
    */
-  
-  [type="number"]::-webkit-inner-spin-button,
-  [type="number"]::-webkit-outer-spin-button {
+
+[type="number"]::-webkit-inner-spin-button,
+[type="number"]::-webkit-outer-spin-button {
     height: auto;
-  }
-  
-  /**
+}
+
+
+/**
    * 1. Correct the odd appearance in Chrome and Safari.
    * 2. Correct the outline style in Safari.
    */
-  
-  [type="search"] {
-    -webkit-appearance: textfield; /* 1 */
-    outline-offset: -2px; /* 2 */
-  }
-  
-  /**
+
+[type="search"] {
+    -webkit-appearance: textfield;
+    /* 1 */
+    outline-offset: -2px;
+    /* 2 */
+}
+
+
+/**
    * Remove the inner padding in Chrome and Safari on macOS.
    */
-  
-  [type="search"]::-webkit-search-decoration {
+
+[type="search"]::-webkit-search-decoration {
     -webkit-appearance: none;
-  }
-  
-  /**
+}
+
+
+/**
    * 1. Correct the inability to style clickable types in iOS and Safari.
    * 2. Change font properties to `inherit` in Safari.
    */
-  
-  ::-webkit-file-upload-button {
-    -webkit-appearance: button; /* 1 */
-    font: inherit; /* 2 */
-  }
-  
-  /* Interactive
+
+::-webkit-file-upload-button {
+    -webkit-appearance: button;
+    /* 1 */
+    font: inherit;
+    /* 2 */
+}
+
+
+/* Interactive
      ========================================================================== */
-  
-  /*
+
+
+/*
    * Add the correct display in Edge, IE 10+, and Firefox.
    */
-  
-  details {
+
+details {
     display: block;
-  }
-  
-  /*
+}
+
+
+/*
    * Add the correct display in all browsers.
    */
-  
-  summary {
+
+summary {
     display: list-item;
-  }
-  
-  /* Misc
+}
+
+
+/* Misc
      ========================================================================== */
-  
-  /**
+
+
+/**
    * Add the correct display in IE 10+.
    */
-  
-  template {
+
+template {
     display: none;
-  }
-  
-  /**
+}
+
+
+/**
    * Add the correct display in IE 10.
    */
-  
-  [hidden] {
+
+[hidden] {
     display: none;
-  }
+}

--- a/terminal/css/terminal.css
+++ b/terminal/css/terminal.css
@@ -315,7 +315,7 @@ ul ul {
 
 .terminal-menu ul {
     list-style-type: none;
-    padding: 0!important;
+    padding: 0 !important;
     display: flex;
     flex-direction: column;
     width: 100%;
@@ -550,31 +550,31 @@ textarea {
 
 input::-webkit-input-placeholder,
 textarea::-webkit-input-placeholder {
-    color: var(--secondary-color)!important;
+    color: var(--secondary-color) !important;
     opacity: 1
 }
 
 input::-moz-placeholder,
 textarea::-moz-placeholder {
-    color: var(--secondary-color)!important;
+    color: var(--secondary-color) !important;
     opacity: 1
 }
 
 input:-ms-input-placeholder,
 textarea:-ms-input-placeholder {
-    color: var(--secondary-color)!important;
+    color: var(--secondary-color) !important;
     opacity: 1
 }
 
 input::-ms-input-placeholder,
 textarea::-ms-input-placeholder {
-    color: var(--secondary-color)!important;
+    color: var(--secondary-color) !important;
     opacity: 1
 }
 
 input::placeholder,
 textarea::placeholder {
-    color: var(--secondary-color)!important;
+    color: var(--secondary-color) !important;
     opacity: 1
 }
 
@@ -732,8 +732,8 @@ textarea:-webkit-autofill:hover textarea:-webkit-autofill:focus {
 }
 
 .btn-small {
-    padding: .5em 1.3em!important;
-    font-size: .9em!important
+    padding: .5em 1.3em !important;
+    font-size: .9em !important
 }
 
 .btn-group {

--- a/terminal/css/theme.css
+++ b/terminal/css/theme.css
@@ -1,4 +1,6 @@
 /*! Terminal for MkDocs | MIT License | github.com/ntno/mkdocs-terminal */
+
+
 /*! terminal.css 0.7.2  | MIT License | github.com/Gioni06/terminal.css */
 
 body {
@@ -6,12 +8,16 @@ body {
     padding-bottom: 50px;
 }
 
+
 /* underline links in main content (except header anchor links) */
-#terminal-mkdocs-main-content a:not(.headerlink){
+
+#terminal-mkdocs-main-content a:not(.headerlink) {
     text-decoration: underline;
 }
 
+
 /* do not underline button links */
+
 a.btn {
     text-decoration: none !important;
 }
@@ -44,20 +50,28 @@ a.btn {
     border-color: var(--error-color);
     color: var(--error-color);
 }
-/* ***************************************************************** */
-/* Terminal.css Overrides */
+
+
 /* ***************************************************************** */
 
+
+/* Terminal.css Overrides */
+
+
+/* ***************************************************************** */
+
+
 /* don't display backticks on `code` items, just highlight */
+
 code::after,
 code::before {
     content: "" !important;
     display: inline;
 }
 
+
 /*! terminal.css | MIT License |  https://github.com/Gioni06/terminal.css/pull/36 */
-blockquote > *:last-child {
+
+blockquote>*:last-child {
     margin-bottom: 0;
 }
-  
-  

--- a/terminal/css/theme.footer.css
+++ b/terminal/css/theme.footer.css
@@ -1,4 +1,5 @@
 /* grid for footer */
+
 .terminal-mkdocs-footer-grid {
     display: grid;
     grid-row-gap: 2em;
@@ -7,7 +8,9 @@
     grid-template-rows: auto;
 }
 
+
 /* place prev/next links to the right of copyright info when screen is wide enough */
+
 @media only screen and (min-width: 50em) {
     .terminal-mkdocs-footer-grid {
         grid-template-columns: 6fr 3fr;
@@ -17,6 +20,6 @@
     }
 }
 
-#terminal-mkdocs-footer-copyright-info{
+#terminal-mkdocs-footer-copyright-info {
     text-align: left;
 }

--- a/terminal/css/theme.tile_grid.css
+++ b/terminal/css/theme.tile_grid.css
@@ -4,21 +4,22 @@
     display: grid;
     grid-gap: 1em;
     grid-template-rows: auto;
-    grid-template-columns: repeat(
-        auto-fit,
-        minmax(calc(var(--page-width) / 6), 1fr)
-    );
+    grid-template-columns: repeat(auto-fit, minmax(calc(var(--page-width) / 6), 1fr));
 }
 
+
 /* center link text within the tile */
+
 .terminal-mkdocs-tile {
     border: none;
     text-align: center;
 }
 
+
 /* center images within the tile */
-.terminal-mkdocs-tile div > figure > img,
-.terminal-mkdocs-tile div > figure > a > img {
+
+.terminal-mkdocs-tile div>figure>img,
+.terminal-mkdocs-tile div>figure>a>img {
     display: block;
     margin-left: auto;
     margin-right: auto;

--- a/terminal/theme_version.html
+++ b/terminal/theme_version.html
@@ -1,1 +1,1 @@
-<meta name="generator" content="mkdocs-{{ mkdocs_version }}, mkdocs-terminal-4.4.0">
+<meta name="generator" content="mkdocs-{{ mkdocs_version }}, mkdocs-terminal-4.4.1">

--- a/terminal/theme_version.html
+++ b/terminal/theme_version.html
@@ -1,1 +1,1 @@
-<meta name="generator" content="mkdocs-{{ mkdocs_version }}, mkdocs-terminal-4.4.1">
+<meta name="generator" content="mkdocs-{{ mkdocs_version }}, mkdocs-terminal-4.4.2">


### PR DESCRIPTION
### Description

This change should be no-op.  It formats the top level CSS files in the [main/terminal/css](https://github.com/ntno/mkdocs-terminal/tree/main/terminal/css) folder using the following config in VSCode:

```json
    "css": {
        "indent_size": 4,
        "indentCharacter": " ",
        "indent_char": " ",
        "selector_separator_newline": true,
        "end_with_newline": false,
        "newline_between_rules": true,
        "eol": "\n"
    }
```

The purpose of this PR is to make future changes to the CSS easier to review.

### Testing

- Firefox: ran the local documentation site locally and compared the pages to the live site.  visual inspection showed that the pages looked the same between sites
- spot checked Safari and Google Chrome