### PR TITLE
Update Test Workflow

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps: 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ inputs.tag }}
   call-metadata-workflow:
@@ -49,7 +49,7 @@ jobs:
       contents: write
     steps: 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ inputs.tag }}
       - name: Install Explicitly Set mkdocs-terminal Version

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     steps: 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ inputs.tag }}
   call-metadata-workflow:
@@ -60,12 +60,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ inputs.tag }}
 
       - name: Set up Python runtime
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,18 +25,11 @@ jobs:
       - if: ${{ matrix.platform == 'macos-latest' }} 
         name: (macos) Install Testing Prereqs
         run: |
-          which tidy
-          tidy --version
-          
           git clone https://github.com/htacg/tidy-html5.git
           cd tidy-html5/build/cmake
           cmake ../.. -DCMAKE_BUILD_TYPE=Release "-DCMAKE_OSX_ARCHITECTURES=x86_64;arm64"
           make 
           sudo make install
-          
-          which tidy
-          tidy --version
-
       - name: Install Tox
         run: make install-tox
       - name: Test Build/Package with Tox

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,8 @@ jobs:
           cd tidy-html5/build/cmake
           cmake ../.. -DCMAKE_BUILD_TYPE=Release "-DCMAKE_OSX_ARCHITECTURES=x86_64;arm64"
           make 
-
+          sudo make install
+          
           which tidy
           tidy --version
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         python: ['3.8', '3.9', '3.10', '3.11', '3.12']
-        platform: [ubuntu-latest, windows-latest, macos-latest]
+        platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,8 +8,8 @@ jobs:
   test:
     strategy:
       matrix:
-        python: ['3.7', '3.8', '3.9', '3.10']
-        platform: [ubuntu-latest, macos-latest, windows-latest]
+        python: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+        platform: [ubuntu-latest] #, macos-latest, windows-latest
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,8 @@ jobs:
         name: (macos) Install Testing Prereqs
         run: |
           brew install tidy-html5
+          tidy --version
+          which tidy
       - name: Install Tox
         run: make install-tox
       - name: Test Build/Package with Tox

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,13 +25,17 @@ jobs:
       - if: ${{ matrix.platform == 'macos-latest' }} 
         name: (macos) Install Testing Prereqs
         run: |
+          which tidy
+          tidy --version
+          
           git clone https://github.com/htacg/tidy-html5.git
           cd tidy-html5/build/cmake
           cmake ../.. -DCMAKE_BUILD_TYPE=Release "-DCMAKE_OSX_ARCHITECTURES=x86_64;arm64"
           make 
-          # brew install tidy-html5
-          # tidy --version
-          # which tidy
+
+          which tidy
+          tidy --version
+
       - name: Install Tox
         run: make install-tox
       - name: Test Build/Package with Tox

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,13 +9,13 @@ jobs:
     strategy:
       matrix:
         python: ['3.8', '3.9', '3.10', '3.11', '3.12']
-        platform: [ubuntu-latest] #, macos-latest, windows-latest
+        platform: [ubuntu-latest, macos-latest] #, windows-latest
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
       - if: ${{ matrix.platform == 'ubuntu-latest' }} 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,9 +25,14 @@ jobs:
       - if: ${{ matrix.platform == 'macos-latest' }} 
         name: (macos) Install Testing Prereqs
         run: |
-          brew install tidy-html5
-          tidy --version
-          which tidy
+          cmake --help
+          git clone git@github.com:htacg/tidy-html5.git
+          cd build/cmake
+          cmake ../.. -DCMAKE_BUILD_TYPE=Release "-DCMAKE_OSX_ARCHITECTURES=x86_64;arm64"
+          make 
+          # brew install tidy-html5
+          # tidy --version
+          # which tidy
       - name: Install Tox
         run: make install-tox
       - name: Test Build/Package with Tox

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         python: ['3.8', '3.9', '3.10', '3.11', '3.12']
-        platform: [ubuntu-latest, windows-latest] #macos-latest,
+        platform: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
   test:
     strategy:
       matrix:
-        python: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python: ['3.8', '3.9', '3.10', '3.11']
         platform: [ubuntu-latest] #, macos-latest, windows-latest
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
   test:
     strategy:
       matrix:
-        python: ['3.8', '3.9', '3.10', '3.11']
+        python: ['3.8', '3.9', '3.10', '3.11', '3.12']
         platform: [ubuntu-latest] #, macos-latest, windows-latest
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,9 +25,8 @@ jobs:
       - if: ${{ matrix.platform == 'macos-latest' }} 
         name: (macos) Install Testing Prereqs
         run: |
-          cmake --help
-          git clone git@github.com:htacg/tidy-html5.git
-          cd build/cmake
+          git clone https://github.com/htacg/tidy-html5.git
+          cd tidy-html5/build/cmake
           cmake ../.. -DCMAKE_BUILD_TYPE=Release "-DCMAKE_OSX_ARCHITECTURES=x86_64;arm64"
           make 
           # brew install tidy-html5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         python: ['3.8', '3.9', '3.10', '3.11', '3.12']
-        platform: [ubuntu-latest, macos-latest] #, windows-latest
+        platform: [ubuntu-latest, windows-latest] #macos-latest,
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
   test:
     strategy:
       matrix:
-        python: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+        python: ['3.7', '3.8', '3.9', '3.10', '3.11']
         platform: [ubuntu-latest] #, macos-latest, windows-latest
     runs-on: ${{ matrix.platform }}
     steps:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mkdocs-terminal",
-    "version": "4.4.0",
+    "version": "4.4.1",
     "description": "Terminal.css theme for MkDocs",
     "keywords": [
         "mkdocs",

--- a/terminal/theme_version.html
+++ b/terminal/theme_version.html
@@ -1,1 +1,1 @@
-<meta name="generator" content="mkdocs-{{ mkdocs_version }}, mkdocs-terminal-4.4.0">
+<meta name="generator" content="mkdocs-{{ mkdocs_version }}, mkdocs-terminal-4.4.1">


### PR DESCRIPTION
### Description

Fixes the [Test PR GitHub Action workflow](https://github.com/ntno/mkdocs-terminal/actions/workflows/test.yml) which is currently broken.

- minimum tested Python version is now 3.8 (up from 3.7)
- maximum tested Python version is now 3.12 (up from 3.10)
- upgraded checkout action step
- upgraded python action step
- fixed [tidy-html5](https://github.com/htacg/tidy-html5) library install on mac-os runner (required for testing)

### References

install instructions for tidy-html5: https://github.com/htacg/tidy-html5/blob/next/README/BUILD.md

### Testing

- workflows are passing
- no code changes other than version bump

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in [mkdocs-terminal/documentation](https://github.com/ntno/mkdocs-terminal/tree/main/documentation/docs)
- [x] All active GitHub checks for tests, formatting, and security are passing

