### PR TITLE
add missing CSS semicolons

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mkdocs-terminal",
-    "version": "4.4.2",
+    "version": "4.4.3",
     "description": "Terminal.css theme for MkDocs",
     "keywords": [
         "mkdocs",

--- a/terminal/css/terminal.css
+++ b/terminal/css/terminal.css
@@ -7,12 +7,12 @@
 
 ::-moz-selection {
     background: var(--primary-color);
-    color: var(--invert-font-color)
+    color: var(--invert-font-color);
 }
 
 ::selection {
     background: var(--primary-color);
-    color: var(--invert-font-color)
+    color: var(--invert-font-color);
 }
 
 body {
@@ -22,7 +22,7 @@ body {
     margin: 0;
     font-family: var(--font-stack);
     word-wrap: break-word;
-    background-color: var(--background-color)
+    background-color: var(--background-color);
 }
 
 .logo,
@@ -32,13 +32,13 @@ h3,
 h4,
 h5,
 h6 {
-    line-height: var(--global-line-height)
+    line-height: var(--global-line-height);
 }
 
 a {
     cursor: pointer;
     color: var(--primary-color);
-    text-decoration: none
+    text-decoration: none;
 }
 
 a:hover {
@@ -50,14 +50,14 @@ em {
     font-size: var(--global-font-size);
     font-style: italic;
     font-family: var(--font-stack);
-    color: var(--font-color)
+    color: var(--font-color);
 }
 
 blockquote,
 code,
 em,
 strong {
-    line-height: var(--global-line-height)
+    line-height: var(--global-line-height);
 }
 
 .logo,
@@ -78,7 +78,7 @@ section,
 ul {
     float: none;
     margin: 0;
-    padding: 0
+    padding: 0;
 }
 
 .logo,
@@ -88,7 +88,7 @@ ol,
 p,
 ul {
     margin-top: calc(var(--global-space) * 2);
-    margin-bottom: calc(var(--global-space) * 2)
+    margin-bottom: calc(var(--global-space) * 2);
 }
 
 .logo,
@@ -107,12 +107,12 @@ h1::after {
     position: absolute;
     bottom: 5px;
     left: 0;
-    display: var(--display-h1-decoration)
+    display: var(--display-h1-decoration);
 }
 
 .logo+*,
 h1+* {
-    margin-top: 0
+    margin-top: 0;
 }
 
 h2,
@@ -122,14 +122,14 @@ h5,
 h6 {
     position: relative;
     margin-bottom: var(--global-line-height);
-    font-weight: 600
+    font-weight: 600;
 }
 
 blockquote {
     position: relative;
     padding-left: calc(var(--global-space) * 2);
     padding-left: 2ch;
-    overflow: hidden
+    overflow: hidden;
 }
 
 blockquote::after {
@@ -139,19 +139,19 @@ blockquote::after {
     top: 0;
     left: 0;
     line-height: var(--global-line-height);
-    color: #9ca2ab
+    color: #9ca2ab;
 }
 
 code {
     font-weight: inherit;
     background-color: var(--code-bg-color);
-    font-family: var(--mono-font-stack)
+    font-family: var(--mono-font-stack);
 }
 
 code::after,
 code::before {
     content: "`";
-    display: inline
+    display: inline;
 }
 
 pre code::after,
@@ -170,7 +170,7 @@ pre {
     white-space: pre-wrap;
     white-space: -moz-pre-wrap;
     white-space: -pre-wrap;
-    white-space: -o-pre-wrap
+    white-space: -o-pre-wrap;
 }
 
 pre code {
@@ -179,7 +179,7 @@ pre code {
     margin: 0;
     display: inline-block;
     min-width: 100%;
-    font-family: var(--mono-font-stack)
+    font-family: var(--mono-font-stack);
 }
 
 .terminal .logo,
@@ -195,16 +195,16 @@ pre code {
     font-size: var(--global-font-size);
     font-style: normal;
     font-family: var(--font-stack);
-    color: var(--font-color)
+    color: var(--font-color);
 }
 
 .terminal-prompt {
     position: relative;
-    white-space: nowrap
+    white-space: nowrap;
 }
 
 .terminal-prompt::before {
-    content: "> "
+    content: "> ";
 }
 
 .terminal-prompt::after {
@@ -218,30 +218,30 @@ pre code {
     margin-left: .2em;
     width: 3px;
     bottom: -2px;
-    position: relative
+    position: relative;
 }
 
 @-webkit-keyframes cursor {
     0% {
-        opacity: 0
+        opacity: 0;
     }
     50% {
-        opacity: 1
+        opacity: 1;
     }
     to {
-        opacity: 0
+        opacity: 0;
     }
 }
 
 @keyframes cursor {
     0% {
-        opacity: 0
+        opacity: 0;
     }
     50% {
-        opacity: 1
+        opacity: 1;
     }
     to {
-        opacity: 0
+        opacity: 0;
     }
 }
 
@@ -249,68 +249,68 @@ li,
 li>ul>li {
     position: relative;
     display: block;
-    padding-left: calc(var(--global-space) * 2)
+    padding-left: calc(var(--global-space) * 2);
 }
 
 nav>ul>li {
-    padding-left: 0
+    padding-left: 0;
 }
 
 li::after {
     position: absolute;
     top: 0;
-    left: 0
+    left: 0;
 }
 
 ul>li::after {
-    content: "-"
+    content: "-";
 }
 
 nav ul>li::after {
-    content: ""
+    content: "";
 }
 
 ol li::before {
     content: counters(item, ".") ". ";
-    counter-increment: item
+    counter-increment: item;
 }
 
 ol ol li::before {
     content: counters(item, ".") " ";
-    counter-increment: item
+    counter-increment: item;
 }
 
 .terminal-menu li::after,
 .terminal-menu li::before {
-    display: none
+    display: none;
 }
 
 ol {
-    counter-reset: item
+    counter-reset: item;
 }
 
 ol li:nth-child(n+10)::after {
-    left: -7px
+    left: -7px;
 }
 
 ol ol {
     margin-top: 0;
-    margin-bottom: 0
+    margin-bottom: 0;
 }
 
 .terminal-menu {
-    width: 100%
+    width: 100%;
 }
 
 .terminal-nav {
     display: flex;
     flex-direction: column;
-    align-items: flex-start
+    align-items: flex-start;
 }
 
 ul ul {
     margin-top: 0;
-    margin-bottom: 0
+    margin-bottom: 0;
 }
 
 .terminal-menu ul {
@@ -321,23 +321,23 @@ ul ul {
     width: 100%;
     flex-grow: 1;
     font-size: var(--global-font-size);
-    margin-top: 0
+    margin-top: 0;
 }
 
 .terminal-menu li {
     display: flex;
     margin: 0 0 .5em 0;
-    padding: 0
+    padding: 0;
 }
 
 ol.terminal-toc li {
     border-bottom: 1px dotted var(--secondary-color);
     padding: 0;
-    margin-bottom: 15px
+    margin-bottom: 15px;
 }
 
 .terminal-menu li:last-child {
-    margin-bottom: 0
+    margin-bottom: 0;
 }
 
 ol.terminal-toc li a {
@@ -346,7 +346,7 @@ ol.terminal-toc li a {
     position: relative;
     top: 6px;
     text-align: left;
-    padding-right: 4px
+    padding-right: 4px;
 }
 
 .terminal-menu li a:not(.btn) {
@@ -354,16 +354,16 @@ ol.terminal-toc li a {
     display: block;
     width: 100%;
     border: none;
-    color: var(--secondary-color)
+    color: var(--secondary-color);
 }
 
 .terminal-menu li a.active {
-    color: var(--font-color)
+    color: var(--font-color);
 }
 
 .terminal-menu li a:hover {
     background: 0 0;
-    color: inherit
+    color: inherit;
 }
 
 ol.terminal-toc li::before {
@@ -373,12 +373,12 @@ ol.terminal-toc li::before {
     right: 0;
     background: var(--background-color);
     padding: 4px 0 4px 4px;
-    bottom: -8px
+    bottom: -8px;
 }
 
 ol.terminal-toc li a:hover {
     background: var(--primary-color);
-    color: var(--invert-font-color)
+    color: var(--invert-font-color);
 }
 
 hr {
@@ -386,36 +386,36 @@ hr {
     overflow: hidden;
     margin: calc(var(--global-space) * 4) 0;
     border: 0;
-    border-bottom: 1px dashed var(--secondary-color)
+    border-bottom: 1px dashed var(--secondary-color);
 }
 
 p {
     margin: 0 0 var(--global-line-height);
-    color: var(--global-font-color)
+    color: var(--global-font-color);
 }
 
 .container {
-    max-width: var(--page-width)
+    max-width: var(--page-width);
 }
 
 .container,
 .container-fluid {
     margin: 0 auto;
-    padding: 0 calc(var(--global-space) * 2)
+    padding: 0 calc(var(--global-space) * 2);
 }
 
 img {
-    width: 100%
+    width: 100%;
 }
 
 .progress-bar {
     height: 8px;
     background-color: var(--progress-bar-background);
-    margin: 12px 0
+    margin: 12px 0;
 }
 
 .progress-bar.progress-bar-show-percent {
-    margin-top: 38px
+    margin-top: 38px;
 }
 
 .progress-bar-filled {
@@ -423,7 +423,7 @@ img {
     height: 100%;
     transition: width .3s ease;
     position: relative;
-    width: 0
+    width: 0;
 }
 
 .progress-bar-filled::before {
@@ -432,7 +432,7 @@ img {
     border-top-color: var(--progress-bar-fill);
     position: absolute;
     top: -12px;
-    right: -6px
+    right: -6px;
 }
 
 .progress-bar-filled::after {
@@ -445,7 +445,7 @@ img {
     border: 6px solid transparent;
     top: -38px;
     right: 0;
-    transform: translateX(50%)
+    transform: translateX(50%);
 }
 
 .progress-bar-no-arrow>.progress-bar-filled::after,
@@ -453,7 +453,7 @@ img {
     content: "";
     display: none;
     visibility: hidden;
-    opacity: 0
+    opacity: 0;
 }
 
 table {
@@ -461,7 +461,7 @@ table {
     border-collapse: collapse;
     margin: var(--global-line-height) 0;
     color: var(--font-color);
-    font-size: var(--global-font-size)
+    font-size: var(--global-font-size);
 }
 
 table td,
@@ -470,39 +470,39 @@ table th {
     border: 1px solid var(--font-color);
     line-height: var(--global-line-height);
     padding: calc(var(--global-space)/ 2);
-    font-size: 1em
+    font-size: 1em;
 }
 
 table thead th {
-    font-size: 1em
+    font-size: 1em;
 }
 
 table tfoot tr th {
-    font-weight: 500
+    font-weight: 500;
 }
 
 table caption {
     font-size: 1em;
-    margin: 0 0 1em 0
+    margin: 0 0 1em 0;
 }
 
 table tbody td:first-child {
     font-weight: 700;
-    color: var(--secondary-color)
+    color: var(--secondary-color);
 }
 
 .form {
-    width: 100%
+    width: 100%;
 }
 
 fieldset {
     border: 1px solid var(--font-color);
-    padding: 1em
+    padding: 1em;
 }
 
 label {
     font-size: 1em;
-    color: var(--font-color)
+    color: var(--font-color);
 }
 
 input[type=email],
@@ -516,7 +516,7 @@ input[type=text] {
     font-size: 1em;
     font-family: var(--font-stack);
     -webkit-appearance: none;
-    border-radius: 0
+    border-radius: 0;
 }
 
 input[type=email]:active,
@@ -531,7 +531,7 @@ input[type=text]:active,
 input[type=text]:focus {
     outline: 0;
     -webkit-appearance: none;
-    border: 1px solid var(--font-color)
+    border: 1px solid var(--font-color);
 }
 
 input[type=email]:not(:placeholder-shown):invalid,
@@ -539,19 +539,19 @@ input[type=number]:not(:placeholder-shown):invalid,
 input[type=password]:not(:placeholder-shown):invalid,
 input[type=search]:not(:placeholder-shown):invalid,
 input[type=text]:not(:placeholder-shown):invalid {
-    border-color: var(--error-color)
+    border-color: var(--error-color);
 }
 
 input,
 textarea {
     color: var(--font-color);
-    background-color: var(--background-color)
+    background-color: var(--background-color);
 }
 
 input::-webkit-input-placeholder,
 textarea::-webkit-input-placeholder {
     color: var(--secondary-color) !important;
-    opacity: 1
+    opacity: 1;
 }
 
 input::-moz-placeholder,
@@ -563,7 +563,7 @@ textarea::-moz-placeholder {
 input:-ms-input-placeholder,
 textarea:-ms-input-placeholder {
     color: var(--secondary-color) !important;
-    opacity: 1
+    opacity: 1;
 }
 
 input::-ms-input-placeholder,
@@ -575,7 +575,7 @@ textarea::-ms-input-placeholder {
 input::placeholder,
 textarea::placeholder {
     color: var(--secondary-color) !important;
-    opacity: 1
+    opacity: 1;
 }
 
 textarea {
@@ -587,17 +587,17 @@ textarea {
     font-size: 1em;
     font-family: var(--font-stack);
     -webkit-appearance: none;
-    border-radius: 0
+    border-radius: 0;
 }
 
 textarea:focus {
     outline: 0;
     -webkit-appearance: none;
-    border: 1px solid var(--font-color)
+    border: 1px solid var(--font-color);
 }
 
 textarea:not(:placeholder-shown):invalid {
-    border-color: var(--error-color)
+    border-color: var(--error-color);
 }
 
 input:-webkit-autofill,
@@ -611,12 +611,12 @@ textarea:-webkit-autofill:hover textarea:-webkit-autofill:focus {
     -webkit-text-fill-color: var(--font-color);
     box-shadow: 0 0 0 1000px var(--invert-font-color) inset;
     -webkit-box-shadow: 0 0 0 1000px var(--invert-font-color) inset;
-    transition: background-color 5000s ease-in-out 0s
+    transition: background-color 5000s ease-in-out 0s;
 }
 
 .form-group {
     margin-bottom: var(--global-line-height);
-    overflow: auto
+    overflow: auto;
 }
 
 .btn {
@@ -635,7 +635,7 @@ textarea:-webkit-autofill:hover textarea:-webkit-autofill:focus {
     -ms-user-select: none;
     user-select: none;
     position: relative;
-    z-index: 1
+    z-index: 1;
 }
 
 .btn:active {
@@ -645,59 +645,59 @@ textarea:-webkit-autofill:hover textarea:-webkit-autofill:focus {
 .btn.btn-ghost {
     border-color: var(--font-color);
     color: var(--font-color);
-    background-color: transparent
+    background-color: transparent;
 }
 
 .btn.btn-ghost:focus,
 .btn.btn-ghost:hover {
     border-color: var(--tertiary-color);
     color: var(--tertiary-color);
-    z-index: 2
+    z-index: 2;
 }
 
 .btn.btn-ghost:hover {
-    background-color: transparent
+    background-color: transparent;
 }
 
 .btn-block {
     width: 100%;
-    display: flex
+    display: flex;
 }
 
 .btn-default {
     background-color: var(--font-color);
     border-color: var(--invert-font-color);
-    color: var(--invert-font-color)
+    color: var(--invert-font-color);
 }
 
 .btn-default:focus:not(.btn-ghost),
 .btn-default:hover {
     background-color: var(--secondary-color);
-    color: var(--invert-font-color)
+    color: var(--invert-font-color);
 }
 
 .btn-default.btn-ghost:focus,
 .btn-default.btn-ghost:hover {
     border-color: var(--secondary-color);
     color: var(--secondary-color);
-    z-index: 2
+    z-index: 2;
 }
 
 .btn-error {
     color: var(--invert-font-color);
     background-color: var(--error-color);
-    border: 1px solid var(--error-color)
+    border: 1px solid var(--error-color);
 }
 
 .btn-error:focus:not(.btn-ghost),
 .btn-error:hover {
     background-color: var(--error-color);
-    border-color: var(--error-color)
+    border-color: var(--error-color);
 }
 
 .btn-error.btn-ghost {
     border-color: var(--error-color);
-    color: var(--error-color)
+    color: var(--error-color);
 }
 
 .btn-error.btn-ghost:focus,
@@ -710,42 +710,42 @@ textarea:-webkit-autofill:hover textarea:-webkit-autofill:focus {
 .btn-primary {
     color: var(--invert-font-color);
     background-color: var(--primary-color);
-    border: 1px solid var(--primary-color)
+    border: 1px solid var(--primary-color);
 }
 
 .btn-primary:focus:not(.btn-ghost),
 .btn-primary:hover {
     background-color: var(--primary-color);
-    border-color: var(--primary-color)
+    border-color: var(--primary-color);
 }
 
 .btn-primary.btn-ghost {
     border-color: var(--primary-color);
-    color: var(--primary-color)
+    color: var(--primary-color);
 }
 
 .btn-primary.btn-ghost:focus,
 .btn-primary.btn-ghost:hover {
     border-color: var(--primary-color);
     color: var(--primary-color);
-    z-index: 2
+    z-index: 2;
 }
 
 .btn-small {
     padding: .5em 1.3em !important;
-    font-size: .9em !important
+    font-size: .9em !important;
 }
 
 .btn-group {
-    overflow: auto
+    overflow: auto;
 }
 
 .btn-group .btn {
-    float: left
+    float: left;
 }
 
 .btn-group .btn-ghost:not(:first-child) {
-    margin-left: -1px
+    margin-left: -1px;
 }
 
 .terminal-card {
@@ -756,16 +756,16 @@ textarea:-webkit-autofill:hover textarea:-webkit-autofill:focus {
     color: var(--invert-font-color);
     text-align: center;
     background-color: var(--secondary-color);
-    padding: .5em 0
+    padding: .5em 0;
 }
 
 .terminal-card>div:first-of-type {
-    padding: var(--global-space)
+    padding: var(--global-space);
 }
 
 .terminal-timeline {
     position: relative;
-    padding-left: 70px
+    padding-left: 70px;
 }
 
 .terminal-timeline::before {
@@ -776,11 +776,11 @@ textarea:-webkit-autofill:hover textarea:-webkit-autofill:focus {
     left: 35px;
     width: 2px;
     height: 100%;
-    z-index: 400
+    z-index: 400;
 }
 
 .terminal-timeline .terminal-card {
-    margin-bottom: 25px
+    margin-bottom: 25px;
 }
 
 .terminal-timeline .terminal-card::before {
@@ -793,39 +793,39 @@ textarea:-webkit-autofill:hover textarea:-webkit-autofill:focus {
     left: 26px;
     width: 15px;
     height: 15px;
-    z-index: 400
+    z-index: 400;
 }
 
 .terminal-alert {
     color: var(--font-color);
     padding: 1em;
     border: 1px solid var(--font-color);
-    margin-bottom: var(--global-space)
+    margin-bottom: var(--global-space);
 }
 
 .terminal-alert-error {
     color: var(--error-color);
-    border-color: var(--error-color)
+    border-color: var(--error-color);
 }
 
 .terminal-alert-primary {
     color: var(--primary-color);
-    border-color: var(--primary-color)
+    border-color: var(--primary-color);
 }
 
 @media screen and (max-width:960px) {
     label {
         display: block;
-        width: 100%
+        width: 100%;
     }
     pre::-webkit-scrollbar {
-        height: 3px
+        height: 3px;
     }
 }
 
 @media screen and (max-width:480px) {
     form {
-        width: 100%
+        width: 100%;
     }
 }
 
@@ -843,43 +843,43 @@ textarea:-webkit-autofill:hover textarea:-webkit-autofill:focus {
     }
     .terminal-menu li {
         margin: 0;
-        margin-right: 2em
+        margin-right: 2em;
     }
     .terminal-menu li:last-child {
-        margin-right: 0
+        margin-right: 0;
     }
 }
 
 .terminal-media:not(:last-child) {
-    margin-bottom: 1.25rem
+    margin-bottom: 1.25rem;
 }
 
 .terminal-media-left {
-    padding-right: var(--global-space)
+    padding-right: var(--global-space);
 }
 
 .terminal-media-left,
 .terminal-media-right {
     display: table-cell;
-    vertical-align: top
+    vertical-align: top;
 }
 
 .terminal-media-right {
-    padding-left: var(--global-space)
+    padding-left: var(--global-space);
 }
 
 .terminal-media-body {
     display: table-cell;
-    vertical-align: top
+    vertical-align: top;
 }
 
 .terminal-media-heading {
     font-size: 1em;
-    font-weight: 700
+    font-weight: 700;
 }
 
 .terminal-media-content {
-    margin-top: .3rem
+    margin-top: .3rem;
 }
 
 .terminal-placeholder {
@@ -887,29 +887,29 @@ textarea:-webkit-autofill:hover textarea:-webkit-autofill:focus {
     text-align: center;
     color: var(--font-color);
     font-size: 1rem;
-    border: 1px solid var(--secondary-color)
+    border: 1px solid var(--secondary-color);
 }
 
 figure>img {
-    padding: 0
+    padding: 0;
 }
 
 .terminal-avatarholder {
     width: calc(var(--global-space) * 5);
-    height: calc(var(--global-space) * 5)
+    height: calc(var(--global-space) * 5);
 }
 
 .terminal-avatarholder img {
-    padding: 0
+    padding: 0;
 }
 
 figure {
-    margin: 0
+    margin: 0;
 }
 
 figure>figcaption {
     color: var(--secondary-color);
-    text-align: center
+    text-align: center;
 }
 
 .hljs {
@@ -917,16 +917,16 @@ figure>figcaption {
     overflow-x: auto;
     padding: .5em;
     background: var(--block-background-color);
-    color: var(--font-color)
+    color: var(--font-color);
 }
 
 .hljs-comment,
 .hljs-quote {
-    color: var(--secondary-color)
+    color: var(--secondary-color);
 }
 
 .hljs-variable {
-    color: var(--font-color)
+    color: var(--font-color);
 }
 
 .hljs-built_in,
@@ -934,7 +934,7 @@ figure>figcaption {
 .hljs-name,
 .hljs-selector-tag,
 .hljs-tag {
-    color: var(--primary-color)
+    color: var(--primary-color);
 }
 
 .hljs-addition,
@@ -946,38 +946,38 @@ figure>figcaption {
 .hljs-template-variable,
 .hljs-title,
 .hljs-type {
-    color: var(--secondary-color)
+    color: var(--secondary-color);
 }
 
 .hljs-string {
-    color: var(--secondary-color)
+    color: var(--secondary-color);
 }
 
 .hljs-deletion,
 .hljs-meta,
 .hljs-selector-attr,
 .hljs-selector-pseudo {
-    color: var(--primary-color)
+    color: var(--primary-color);
 }
 
 .hljs-doctag {
-    color: var(--secondary-color)
+    color: var(--secondary-color);
 }
 
 .hljs-attr {
-    color: var(--primary-color)
+    color: var(--primary-color);
 }
 
 .hljs-bullet,
 .hljs-link,
 .hljs-symbol {
-    color: var(--primary-color)
+    color: var(--primary-color);
 }
 
 .hljs-emphasis {
-    font-style: italic
+    font-style: italic;
 }
 
 .hljs-strong {
-    font-weight: 700
+    font-weight: 700;
 }

--- a/terminal/theme_version.html
+++ b/terminal/theme_version.html
@@ -1,1 +1,1 @@
-<meta name="generator" content="mkdocs-{{ mkdocs_version }}, mkdocs-terminal-4.4.2">
+<meta name="generator" content="mkdocs-{{ mkdocs_version }}, mkdocs-terminal-4.4.3">


### PR DESCRIPTION
### Description

bringing CSS formatting up to standard with the 0.7.4 terminal.css release in order to make reviewing the changes easier

### References
relates to PRs #145 and #143 

### Testing

spun up local documentation server in Firefox and spot checked

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in [mkdocs-terminal/documentation](https://github.com/ntno/mkdocs-terminal/tree/main/documentation/docs)
- [x] All active GitHub checks for tests, formatting, and security are passing

