### PR TITLE
Update docs for 4 5

### DIFF
--- a/documentation/requirements.txt
+++ b/documentation/requirements.txt
@@ -1,5 +1,5 @@
 mkdocs
-mkdocs-terminal~=4.3
+mkdocs-terminal~=4.5
 
 # Python Markdown Extensions
 pygments>=2.14

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,71 +1,13 @@
 {
     "name": "mkdocs-terminal",
-    "version": "4.3.0",
+    "version": "4.5.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
-        "cp-file": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/cp-file/-/cp-file-7.0.0.tgz",
-            "integrity": "sha512-0Cbj7gyvFVApzpK/uhCtQ/9kE9UnYpxMzaq5nQQC/Dh4iaj5fxp7iEFIullrYwzj8nf0qnsI1Qsx34hAeAebvw==",
-            "requires": {
-                "graceful-fs": "^4.1.2",
-                "make-dir": "^3.0.0",
-                "nested-error-stacks": "^2.0.0",
-                "p-event": "^4.1.0"
-            }
-        },
-        "graceful-fs": {
-            "version": "4.2.10",
-            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-            "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
-        },
-        "make-dir": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-            "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-            "requires": {
-                "semver": "^6.0.0"
-            }
-        },
-        "nested-error-stacks": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-2.1.1.tgz",
-            "integrity": "sha512-9iN1ka/9zmX1ZvLV9ewJYEk9h7RyRRtqdK0woXcqohu8EWIerfPUjYJPg0ULy0UqP7cslmdGc8xKDJcojlKiaw=="
-        },
-        "p-event": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/p-event/-/p-event-4.2.0.tgz",
-            "integrity": "sha512-KXatOjCRXXkSePPb1Nbi0p0m+gQAwdlbhi4wQKJPI1HsMQS9g+Sqp2o+QHziPr7eYJyOZet836KoHEVM1mwOrQ==",
-            "requires": {
-                "p-timeout": "^3.1.0"
-            }
-        },
-        "p-finally": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-            "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow=="
-        },
-        "p-timeout": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
-            "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
-            "requires": {
-                "p-finally": "^1.0.0"
-            }
-        },
-        "semver": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-        },
         "terminal.css": {
-            "version": "0.7.2",
-            "resolved": "https://registry.npmjs.org/terminal.css/-/terminal.css-0.7.2.tgz",
-            "integrity": "sha512-Mo/zv2aKNjBC9Chv8eszRVNAGZu3o2JUP/5A4zuFVn5ZNOrBBo69TI/HTsQIFvYp0ISVNSTmFakiXdp8R/wE1Q==",
-            "requires": {
-                "cp-file": "^7.0.0"
-            }
+            "version": "0.7.5",
+            "resolved": "https://registry.npmjs.org/terminal.css/-/terminal.css-0.7.5.tgz",
+            "integrity": "sha512-M4RU7IRzqSZoJNRZCmxbRJqjxZqP2eV5cWyUlfAwqJx2GkoHlakTyoPLj0tLJwVJurfac38MwL5Mpwr23Yb0ow=="
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mkdocs-terminal",
-    "version": "4.5.0",
+    "version": "4.5.1",
     "description": "Terminal.css theme for MkDocs",
     "keywords": [
         "mkdocs",

--- a/terminal/theme_version.html
+++ b/terminal/theme_version.html
@@ -1,1 +1,1 @@
-<meta name="generator" content="mkdocs-{{ mkdocs_version }}, mkdocs-terminal-4.5.0">
+<meta name="generator" content="mkdocs-{{ mkdocs_version }}, mkdocs-terminal-4.5.1">


### PR DESCRIPTION
update live documentation site to use version 4.5.0


### Testing
installed package locally and spun up documentation server 

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in [mkdocs-terminal/documentation](https://github.com/ntno/mkdocs-terminal/tree/main/documentation/docs)
- [ ] All active GitHub checks for tests, formatting, and security are passing

