### PR TITLE
fix local development target - serve-local-theme

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -70,7 +70,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Set up Python dependencies
-        run: pip install --upgrade build twine
+        run: pip install --upgrade build packaging twine
 
       - name: Build Python package
         run: python -m build

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ serve-local-theme:
 #########################################################
 
 install-build-requirements:
-	pip install --upgrade build
+	pip install --upgrade build packaging
 
 build-pip-dist:
 	python -m build --outdir ./dist

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mkdocs-terminal",
-    "version": "4.6.0",
+    "version": "4.6.1",
     "description": "Terminal.css theme for MkDocs",
     "keywords": [
         "mkdocs",

--- a/terminal/theme_version.html
+++ b/terminal/theme_version.html
@@ -1,1 +1,1 @@
-<meta name="generator" content="mkdocs-{{ mkdocs_version }}, mkdocs-terminal-4.6.0">
+<meta name="generator" content="mkdocs-{{ mkdocs_version }}, mkdocs-terminal-4.6.1">


### PR DESCRIPTION
fixes bug where `make serve-local-theme` target fails with a pip packaging error:

```
pip install dist/*.tar.gz
Processing ./dist/mkdocs_terminal-4.6.0.tar.gz
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... error
  error: subprocess-exited-with-error

  × Preparing metadata (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [14 lines of output]
      Traceback (most recent call last):
        File "/usr/local/lib/python3.8/dist-packages/pip/_vendor/pep517/in_process/_in_process.py", line 363, in <module>
          main()
        File "/usr/local/lib/python3.8/dist-packages/pip/_vendor/pep517/in_process/_in_process.py", line 345, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])
        File "/usr/local/lib/python3.8/dist-packages/pip/_vendor/pep517/in_process/_in_process.py", line 164, in prepare_metadata_for_build_wheel
          return hook(metadata_directory, config_settings)
        File "/tmp/pip-build-env-j1s_yw3o/overlay/lib/python3.8/site-packages/hatchling/build.py", line 117, in prepare_metadata_for_build_wheel
          f.write(builder.config.core_metadata_constructor(builder.metadata))
        File "/tmp/pip-build-env-j1s_yw3o/overlay/lib/python3.8/site-packages/hatchling/metadata/spec.py", line 546, in construct_metadata_file_2_4
          if metadata.core.license:
        File "/tmp/pip-build-env-j1s_yw3o/overlay/lib/python3.8/site-packages/hatchling/metadata/core.py", line 677, in license
          from packaging.licenses import canonicalize_license_expression
      ModuleNotFoundError: No module named 'packaging.licenses'
      [end of output]
```