### PR TITLE
example highlightjs configuration

### DIFF
--- a/tests/examples/highlightjs/docs/highlight.js
+++ b/tests/examples/highlightjs/docs/highlight.js
@@ -1,0 +1,5 @@
+window.addEventListener('load', hljs_highlight, false);
+
+function hljs_highlight() {
+    hljs.highlightAll();
+}

--- a/tests/examples/highlightjs/docs/index.md
+++ b/tests/examples/highlightjs/docs/index.md
@@ -1,0 +1,41 @@
+# Highlight.js Example Site
+
+This example site uses the [highlight.js] javascript library to add code highlighting after the page is loaded in the user's web browser.
+
+[highlight.js]: https://highlightjs.org/
+
+
+## Configuration
+
+### Include highlight.js Scripts/Styles
+
+Specify the `highlight.js` javascript and CSS source files.  At a minimum you will need to include the main script `highlight.min.js` and stylesheet `default.min.css`.  You should also specify language specific scripts as needed.
+
+`mkdocs.yml` excerpt:
+
+```yaml
+theme:
+  name: terminal
+
+extra_javascript:
+  - https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.10.0/highlight.min.js
+  - https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.10.0/languages/bash.min.js
+  - https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.10.0/languages/javascript.min.js
+  - https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.10.0/languages/python.min.js
+  - highlight.js
+
+extra_css:
+  - https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.10.0/styles/default.min.css
+```
+
+### Include Custom Highlighter Code
+
+Add a custom javascript file which will trigger the `highlight.js` library to highlight code blocks after an HTML page loads.  You can add the file to `docs/highlight.js` and reference it in the `extra_javascript` section of `mkdocs.yml`:
+
+```javascript
+window.addEventListener('load', hljs_highlight, false);
+
+function hljs_highlight() {
+    hljs.highlightAll();
+}
+```

--- a/tests/examples/highlightjs/docs/languages/bash.md
+++ b/tests/examples/highlightjs/docs/languages/bash.md
@@ -1,0 +1,16 @@
+# Bash
+
+Here's a sample bash script:
+
+```bash
+#!/bin/bash
+echo "Today is " `date`
+
+echo -e "\nenter the path to a directory"
+read the_path
+
+echo -e "\nthis path has the following files and folders: "
+ls $the_path
+```
+
+Script adapted from Zaira Hira's ["Bash Scripting Tutorial Linux Shell Script and Command Line For Beginners"](https://www.freecodecamp.org/news/bash-scripting-tutorial-linux-shell-script-and-command-line-for-beginners/)

--- a/tests/examples/highlightjs/docs/languages/javascript.md
+++ b/tests/examples/highlightjs/docs/languages/javascript.md
@@ -1,0 +1,9 @@
+# javascript
+
+This is a javascript code snippet:
+
+```javascript
+const numbers = [102, -1, 2];
+numbers.sort((a, b) => a - b);
+console.log(numbers);
+```

--- a/tests/examples/highlightjs/docs/languages/python.md
+++ b/tests/examples/highlightjs/docs/languages/python.md
@@ -1,0 +1,7 @@
+# python
+
+This is a python code snippet:
+
+```python
+[x for x in range(1, 10) if x % 2]
+```

--- a/tests/examples/highlightjs/mkdocs.yml
+++ b/tests/examples/highlightjs/mkdocs.yml
@@ -1,10 +1,8 @@
-site_url: https://ntno.github.io/mkdocs-terminal
-repo_url: https://github.com/ntno/mkdocs-terminal
+site_name: Terminal Theme with Highlight.js
+site_url: https://ntno.github.io/mkdocs-terminal-example-highlightjs
 copyright: Copyright 2024 Natan Organick, All rights reserved
 site_author: ntno
 
-
-site_name: Terminal Theme with Highlight.js
 nav:
     - Home: 'index.md'
     - Languages: 

--- a/tests/examples/highlightjs/mkdocs.yml
+++ b/tests/examples/highlightjs/mkdocs.yml
@@ -1,0 +1,31 @@
+site_url: https://ntno.github.io/mkdocs-terminal
+repo_url: https://github.com/ntno/mkdocs-terminal
+copyright: Copyright 2024 Natan Organick, All rights reserved
+site_author: ntno
+
+
+site_name: Terminal Theme with Highlight.js
+nav:
+    - Home: 'index.md'
+    - Languages: 
+      - Bash: 'languages/bash.md'
+      - Python: 'languages/python.md'
+      - Javascript: 'languages/javascript.md'
+    
+
+theme:
+  name: terminal
+  features:
+    - navigation.side.indexes
+
+extra_javascript:
+  - https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.10.0/highlight.min.js
+  - https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.10.0/languages/bash.min.js
+  - https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.10.0/languages/javascript.min.js
+  - https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.10.0/languages/python.min.js
+  - highlight.js
+
+extra_css:
+  - https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.10.0/styles/default.min.css
+
+              

--- a/tests/examples/highlightjs/requirements.txt
+++ b/tests/examples/highlightjs/requirements.txt
@@ -1,0 +1,2 @@
+mkdocs
+mkdocs-terminal~=4.0


### PR DESCRIPTION
### Description

example configuration for enabling browser-side code highlighting with the `highlight.js` library


### References

- [highlight.js library](https://highlightjs.org/)
- [highlight.js docs](https://highlightjs.readthedocs.io/en/latest/)
- stop gap for #81 

### Testing

run the sub-site locally:
```
make serve site=highlightjs
```

#### bash example
![Screen Shot 2024-12-17 at 7 22 56 PM](https://github.com/user-attachments/assets/41c8bc82-696c-4137-b814-6446c3133a61)

#### javascript example
![Screen Shot 2024-12-17 at 7 22 51 PM](https://github.com/user-attachments/assets/2715d31c-69ab-4508-a3ec-d50cb68244e4)

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in [mkdocs-terminal/documentation](https://github.com/ntno/mkdocs-terminal/tree/main/documentation/docs)
- [ ] All active GitHub checks for tests, formatting, and security are passing

