### PR TITLE
Fix markdown language tags in documentation

### DIFF
--- a/DEVELOPER_README.md
+++ b/DEVELOPER_README.md
@@ -55,7 +55,7 @@ You should be able to visit [http://0.0.0.0:8080/mkdocs-terminal/](http://0.0.0.
 If you get a `docker.sock: connect: permission denied` error, you probably need to start the Docker engine on your machine.  
 
 **Example Error**:
-```
+```log
 Got permission denied while trying to connect to the Docker daemon socket at unix:///var/run/docker.sock: Get "http://%2Fvar%2Frun%2Fdocker.sock/v1.24/containers/json?all=1&filters=%7B%22label%22%3A%7B%22com.docker.compose.project%3Dmkdocs-terminal%22%3Atrue%7D%7D&limit=0": dial unix /var/run/docker.sock: connect: permission denied
 make: *** [ubuntu] Error 1
 ```

--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ In addition to simple, monospace styling, Terminal for MkDocs also provides:
 
 terminal.css theme for MkDocs can be installed with `pip`:
 
-``` sh
+```bash
 pip install mkdocs-terminal
 ```
 
 Add the following lines to `mkdocs.yml`:
 
-``` yaml
+```yaml
 theme:
   name: terminal
 ```

--- a/documentation/docs/configuration/extensions/index.md
+++ b/documentation/docs/configuration/extensions/index.md
@@ -44,7 +44,7 @@ Extensions are enabled in the MkDocs configuration file.  See below for two exam
 
 The minimal configuration is a good starting point for when you're using MkDocs for the first time.  You can explore the suggested extensions and gradually add extensions as needed:
 
-``` yaml
+```yaml
 markdown_extensions:
   # Python Markdown  
   - attr_list
@@ -59,7 +59,7 @@ markdown_extensions:
 The recommended configuration enables all Markdown-related features of Terminal for MkDocs
 and is great for experienced users bootstrapping a new documentation project:
 
-``` yaml
+```yaml
 markdown_extensions:
   # Python Markdown  
   - attr_list

--- a/documentation/docs/configuration/extensions/pymdown-extensions.md
+++ b/documentation/docs/configuration/extensions/pymdown-extensions.md
@@ -16,7 +16,7 @@ The [Caret], [Mark], and [Tilde] extensions add the ability to highlight text
 and define subscript and superscript using a simple syntax. Enable them together
 via `mkdocs.yml`:
 
-``` yaml
+```yaml
 markdown_extensions:
   - pymdownx.caret
   - pymdownx.mark
@@ -46,7 +46,7 @@ See reference for usage:
 
 The [Snippets] extension adds the ability to embed content from arbitrary files into a document, including other documents or source files, by using a simple syntax. Enable it via `mkdocs.yml`:
 
-``` yaml
+```yaml
 markdown_extensions:
   - pymdownx.snippets
 ```

--- a/documentation/docs/configuration/extensions/python-markdown.md
+++ b/documentation/docs/configuration/extensions/python-markdown.md
@@ -14,7 +14,7 @@ Terminal for MkDocs is compatible with some of the [Python Markdown] extensions.
 
 The [Attribute Lists] extension helps to add HTML attributes and CSS classes to Markdown inline and block-level elements. Enable it via `mkdocs.yml`:
 
-``` yaml
+```yaml
 markdown_extensions:
   - attr_list
 ```
@@ -34,7 +34,7 @@ No configuration options are available. See reference for usage:
 
 The [Definition Lists] extension adds a Markdown syntax for definition lists (more commonly known as [description lists]). Enable it via `mkdocs.yml`:
 
-``` yaml
+```yaml
 markdown_extensions:
   - def_list
 ```
@@ -51,7 +51,7 @@ No configuration options are available. See reference for usage:
 
 The [Footnotes] extension enables inline footnotes which are then rendered below all of a document's Markdown content.  Enable it via `mkdocs.yml`:
 
-``` yaml
+```yaml
 markdown_extensions:
   - footnotes
 ```
@@ -70,7 +70,7 @@ See reference for usage:
 The [Markdown in HTML] extension allows for writing Markdown inside of HTML, which is useful for wrapping Markdown content with custom elements. Enable it
 via `mkdocs.yml`:
 
-``` yaml
+```yaml
 markdown_extensions:
   - md_in_html
 ```
@@ -93,7 +93,7 @@ No configuration options are available. See reference for usage:
 
 The [Table of Contents] extension automatically generates a table of contents from a document which Terminal for MkDocs will render as part of the resulting page. It can be configured via `mkdocs.yml`:
 
-``` yaml
+```yaml
 markdown_extensions:
   - toc:
       permalink: "#"
@@ -134,7 +134,7 @@ See reference for usage:
 
 The [Tables] extension adds a Markdown syntax for data tables.  It is enabled by default but you can specify it explicitly in `mkdocs.yml`:
 
-``` yaml
+```yaml
 markdown_extensions:
   - tables
 ```

--- a/documentation/docs/elements/code.md
+++ b/documentation/docs/elements/code.md
@@ -8,7 +8,7 @@ For convenience, inline code blocks can also be specified by enclosing text betw
 
 ## Code Block
 
-```
+```javascript
 const numbers = [102, -1, 2]; 
 numbers.sort((a, b) => a - b);
 console.log(numbers);
@@ -16,8 +16,8 @@ console.log(numbers);
 
 ## Code Block Markdown
 
-````
-```
+````markdown
+```javascript
 const numbers = [102, -1, 2];
 numbers.sort((a, b) => a - b);
 console.log(numbers);
@@ -30,6 +30,6 @@ The ```printf``` and ```echo``` commands can be used to print text to the screen
 
 ### Inline Code Markdown
 
-````
+````markdown
 The ```printf``` and ```echo``` commands can be used to print text to the screen in a shell session.  However, `printf` supports text formatting and `echo` does not.
 ````

--- a/documentation/docs/elements/footnotes.md
+++ b/documentation/docs/elements/footnotes.md
@@ -11,7 +11,7 @@ This configuration adds the ability to define inline footnotes, which are then
 rendered below all Markdown content of a document. Add the following lines to
 `mkdocs.yml`:
 
-``` yaml
+```yaml
 markdown_extensions:
   - footnotes
 ```

--- a/documentation/docs/elements/table.md
+++ b/documentation/docs/elements/table.md
@@ -23,7 +23,7 @@ Colons can be used to align columns.  Note that the "Release" column is centered
 |  0.0.0  | no         |
 
 ## Markdown
-```
+```markdown
 | Release | Supported? |
 | :-----: | ---------: |
 |  1.0.0  | yes        |

--- a/documentation/docs/tile-grid/examples/override-styling.md
+++ b/documentation/docs/tile-grid/examples/override-styling.md
@@ -52,7 +52,7 @@ To demonstrate how the tile grid's style can be overriden, the following `<style
 - `#grid_123`: sets the tile grid's column widths explicitly  
 
 
-```css
+```html
 <style> 
     .override_border { 
         border: dashed;

--- a/documentation/docs/tile-grid/grid.md
+++ b/documentation/docs/tile-grid/grid.md
@@ -1,7 +1,7 @@
 # Grid Reference
 Terminal for MkDocs Tile Grid can be further customized using the following configuration options.  These options should be specified in the markdown page's metadata in the same way that `tiles` are specified:
 
-```
+```markdown
 ---
 show_tiles_first: true
 tiles:

--- a/documentation/docs/tile-grid/index.md
+++ b/documentation/docs/tile-grid/index.md
@@ -42,7 +42,7 @@ Add the markdown file which includes the `tiles` metadata to the site's navigati
 
 *Note*: the page does not need to be visible in the final side navigation menu.  Deeply nested pages can also use the tile grid feature.  
 
-```
+```yaml
 nav:
     - Home: 'index.md'
     - Example Page: 'tile-grid/examples/example-page.md'
@@ -74,7 +74,7 @@ tiles:
 file location: `.`  
 filename: `mkdocs.yml`  
 
-```
+```yaml
 site_name: Tile Grid Demo
 
 nav:

--- a/notes/NOTES.md
+++ b/notes/NOTES.md
@@ -5,7 +5,7 @@
 #### (####) Canis (wolves, dogs, coyotes)
 ## Hideable Components
 In order to hide components on a per-page basis, you need the meta markdown extension
-```mkdocs.yml
+```yaml
 markdown_extensions:
   - meta
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mkdocs-terminal",
-    "version": "4.7.2",
+    "version": "4.7.3",
     "description": "Terminal.css theme for MkDocs",
     "keywords": [
         "mkdocs",

--- a/terminal/legal/legal.md
+++ b/terminal/legal/legal.md
@@ -195,7 +195,7 @@ THE SOFTWARE.
 ```  
 
 [fontawesome](https://fontawesome.com/license/free)  
-```css
+```javascript
 /*!
  * Font Awesome Free 6.2.1 by @fontawesome - https://fontawesome.com
  * License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License)

--- a/terminal/theme_version.html
+++ b/terminal/theme_version.html
@@ -1,1 +1,1 @@
-<meta name="generator" content="mkdocs-{{ mkdocs_version }}, mkdocs-terminal-4.7.2">
+<meta name="generator" content="mkdocs-{{ mkdocs_version }}, mkdocs-terminal-4.7.3">

--- a/tests/examples/demo/docs/section-index-notes.md
+++ b/tests/examples/demo/docs/section-index-notes.md
@@ -5,7 +5,7 @@ When section index pages are enabled, documents can be directly attached to
 sections, which is particularly useful for providing overview pages. Add the
 following lines to `mkdocs.yml`:
 
-``` yaml
+```yaml
 theme:
   features:
     - navigation.indexes # (1)!
@@ -26,7 +26,7 @@ In order to link a page to a section, create a new document with the name
 `index.md` in the respective folder, and add it to the beginning of your
 navigation section:
 
-``` yaml
+```yaml
 nav:
   - Section:
     - section/index.md


### PR DESCRIPTION
- adds missing language-specifiers to markdown blocks
- removes extra whitespace for consistency / future find-replace
