### PR TITLE
Document adding admonitions through PyMdown

### DIFF
--- a/documentation/docs/configuration/extensions/pymdown-extensions.md
+++ b/documentation/docs/configuration/extensions/pymdown-extensions.md
@@ -113,7 +113,7 @@ markdown_extensions:
           title: ''
 ```
 
-If you wish to use different admonition types, you can change the types above, and then define the custom classes in a [css overide](/tile-grid/examples/overide-styling).
+If you wish to use different admonition types, you can change the types above, and then define the custom classes in a [css overide](/tile-grid/examples/override-styling).
 
   [Details]: https://facelessuser.github.io/pymdown-extensions/extensions/blocks/plugins/details/
 

--- a/documentation/docs/configuration/extensions/pymdown-extensions.md
+++ b/documentation/docs/configuration/extensions/pymdown-extensions.md
@@ -94,6 +94,28 @@ See reference for recommended configuration options:
   [Highlight]: https://facelessuser.github.io/pymdown-extensions/extensions/highlight/
   [InlineHilite]: https://facelessuser.github.io/pymdown-extensions/extensions/inlinehilite/
 
+## Admonitions
+
+The [Details] extension can be used to create admonitions (sometimes called callouts). By default, mkdocs terminal supports three admonition types: default, error, and primary. Enable them via `mkdocs.yml`:
+
+```yaml
+markdown_extensions:
+  - pymdownx.blocks.details:
+      types:
+        - name: 'default'
+          class: 'terminal-alert'
+          title: ''
+        - name: 'error'
+          class: 'terminal-alert-error'
+          title: ''
+        - name: 'primary'
+          class: 'terminal-alert-primary'
+          title: ''
+```
+
+If you wish to add more admonition types, you can change the types above, and then define the custom classes in a [css overide](tile-grid/examples/overide-styling).
+
+  [Details]: https://facelessuser.github.io/pymdown-extensions/extensions/blocks/plugins/details/
 
 # Credit
 

--- a/documentation/docs/configuration/extensions/pymdown-extensions.md
+++ b/documentation/docs/configuration/extensions/pymdown-extensions.md
@@ -113,7 +113,7 @@ markdown_extensions:
           title: ''
 ```
 
-If you wish to use different admonition types, you can change the types above, and then define the custom classes in a [css overide](/tile-grid/examples/override-styling).
+If you wish to use different admonition types, you can change the types above, and then define the custom classes in a [css override](/tile-grid/examples/override-styling).
 
   [Details]: https://facelessuser.github.io/pymdown-extensions/extensions/blocks/plugins/details/
 

--- a/documentation/docs/configuration/extensions/pymdown-extensions.md
+++ b/documentation/docs/configuration/extensions/pymdown-extensions.md
@@ -130,6 +130,10 @@ markdown_extensions:
   [Details]: https://facelessuser.github.io/pymdown-extensions/extensions/blocks/plugins/details/
   [extra_css MkDocs feature]: https://www.mkdocs.org/user-guide/configuration/#extra_css
 
+See reference for usage:
+- [Adding Details]
+  [Adding Details]: ../../../elements/details
+
 # Credit
 
 This documentation page is based on squidfunk's [Material for MkDocs Pymdown Extension](https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown-extensions/) documentation.

--- a/documentation/docs/configuration/extensions/pymdown-extensions.md
+++ b/documentation/docs/configuration/extensions/pymdown-extensions.md
@@ -96,7 +96,7 @@ See reference for recommended configuration options:
 
 ## Details
 
-The [Details] extension can be used to create admonitions (sometimes called callouts). By default, mkdocs terminal supports three details types. Enable them via `mkdocs.yml`:
+The [Details] extension can be used to create admonitions (sometimes called callouts). By default, Terminal for Mkdocs supports three categories. Enable them via `mkdocs.yml`:
 
 /// info
 This is an info block
@@ -125,9 +125,10 @@ markdown_extensions:
           title: Important
 ```
 
-If you wish to use different detail types, you can change the types above, and then define the custom classes in a extra_css file.
-
+* To use different categories, update the `name` attribute.
+* To use a custom style, update the `class` attribute to the name of your custom CSS class (remember to load the custom CSS via the [extra_css MkDocs feature]).
   [Details]: https://facelessuser.github.io/pymdown-extensions/extensions/blocks/plugins/details/
+  [extra_css MkDocs feature]: https://www.mkdocs.org/user-guide/configuration/#extra_css
 
 # Credit
 

--- a/documentation/docs/configuration/extensions/pymdown-extensions.md
+++ b/documentation/docs/configuration/extensions/pymdown-extensions.md
@@ -118,10 +118,10 @@ markdown_extensions:
           class: terminal-alert
           title: Info
         - name: warning
-          class: terminal-alert-error
+          class: 'terminal-alert terminal-alert-error'
           title: Warning
         - name: important
-          class: terminal-alert-primary
+          class: 'terminal-alert terminal-alert-primary'
           title: Important
 ```
 

--- a/documentation/docs/configuration/extensions/pymdown-extensions.md
+++ b/documentation/docs/configuration/extensions/pymdown-extensions.md
@@ -113,7 +113,7 @@ markdown_extensions:
           title: ''
 ```
 
-If you wish to add more admonition types, you can change the types above, and then define the custom classes in a [css overide](tile-grid/examples/overide-styling).
+If you wish to use different admonition types, you can change the types above, and then define the custom classes in a [css overide](tile-grid/examples/overide-styling).
 
   [Details]: https://facelessuser.github.io/pymdown-extensions/extensions/blocks/plugins/details/
 

--- a/documentation/docs/configuration/extensions/pymdown-extensions.md
+++ b/documentation/docs/configuration/extensions/pymdown-extensions.md
@@ -113,7 +113,7 @@ markdown_extensions:
           title: ''
 ```
 
-If you wish to use different admonition types, you can change the types above, and then define the custom classes in a [css overide](tile-grid/examples/overide-styling).
+If you wish to use different admonition types, you can change the types above, and then define the custom classes in a [css overide](/tile-grid/examples/overide-styling).
 
   [Details]: https://facelessuser.github.io/pymdown-extensions/extensions/blocks/plugins/details/
 

--- a/documentation/docs/configuration/extensions/pymdown-extensions.md
+++ b/documentation/docs/configuration/extensions/pymdown-extensions.md
@@ -94,26 +94,38 @@ See reference for recommended configuration options:
   [Highlight]: https://facelessuser.github.io/pymdown-extensions/extensions/highlight/
   [InlineHilite]: https://facelessuser.github.io/pymdown-extensions/extensions/inlinehilite/
 
-## Admonitions
+## Details
 
-The [Details] extension can be used to create admonitions (sometimes called callouts). By default, mkdocs terminal supports three admonition types: default, error, and primary. Enable them via `mkdocs.yml`:
+The [Details] extension can be used to create admonitions (sometimes called callouts). By default, mkdocs terminal supports three details types. Enable them via `mkdocs.yml`:
+
+/// info
+This is an info block
+///
+
+/// warning
+This is a warning
+///
+
+/// important
+This is important
+///
 
 ```yaml
 markdown_extensions:
   - pymdownx.blocks.details:
       types:
-        - name: 'default'
-          class: 'terminal-alert'
-          title: ''
-        - name: 'error'
-          class: 'terminal-alert-error'
-          title: ''
-        - name: 'primary'
-          class: 'terminal-alert-primary'
-          title: ''
+        - name: info 
+          class: terminal-alert
+          title: Info
+        - name: warning
+          class: terminal-alert-error
+          title: Warning
+        - name: important
+          class: terminal-alert-primary
+          title: Important
 ```
 
-If you wish to use different admonition types, you can change the types above, and then define the custom classes in a [css override](/tile-grid/examples/override-styling).
+If you wish to use different detail types, you can change the types above, and then define the custom classes in a extra_css file.
 
   [Details]: https://facelessuser.github.io/pymdown-extensions/extensions/blocks/plugins/details/
 

--- a/documentation/docs/elements/details.md
+++ b/documentation/docs/elements/details.md
@@ -10,10 +10,10 @@ markdown_extensions:
           class: terminal-alert
           title: Info
         - name: warn
-          class: terminal-alert-error
+          class: terminal-alert terminal-alert-error
           title: Warning
         - name: important
-          class: terminal-alert-primary
+          class: terminal-alert terminal-alert-primary
           title: Important
 ```
 

--- a/documentation/docs/elements/details.md
+++ b/documentation/docs/elements/details.md
@@ -31,6 +31,15 @@ This is a warning
 This is important
 ///
 
+/// info | Note
+This is an info block with the title overwritten to "Note"
+///
+
+/// warning
+    open: True
+This is a warning that is expanded by default
+///
+
 # Markdown
 
 ```markdown
@@ -44,6 +53,15 @@ This is a warning
 
 /// important
 This is important
+///
+
+/// info | Note
+This is an info block with the title overwritten to "Note"
+///
+
+/// warning
+    open: True
+This is a warning that is expanded by default
 ///
 ```
 

--- a/documentation/docs/elements/details.md
+++ b/documentation/docs/elements/details.md
@@ -1,0 +1,50 @@
+# Details setup
+
+Enabling detail blocks requires the `pymdown.blocks.details` extension. Add it to the `markdown_extensions` configuration in `mkdocs.yml`:
+
+```yaml
+markdown_extensions:
+  - pymdownx.blocks.details:
+      types:
+        - name: info
+          class: terminal-alert
+          title: Info
+        - name: warn
+          class: terminal-alert-error
+          title: Warning
+        - name: important
+          class: terminal-alert-primary
+          title: Important
+```
+
+# Example
+
+/// info
+This is an info block
+///
+
+/// warning
+This is a warning
+///
+
+/// important
+This is important
+///
+
+# Markdown
+
+```markdown
+/// info
+This is an info block
+///
+
+/// warning
+This is a warning
+///
+
+/// important
+This is important
+///
+```
+
+

--- a/documentation/mkdocs.yml
+++ b/documentation/mkdocs.yml
@@ -82,10 +82,10 @@ markdown_extensions:
           class: terminal-alert
           title: Info
         - name: warning
-          class: terminal-alert-error
+          class: 'terminal-alert terminal-alert-error'
           title: Warning
         - name: important
-          class: terminal-alert-primary
+          class: 'terminal-alert terminal-alert-primary'
           title: Important
 
 plugins:

--- a/documentation/mkdocs.yml
+++ b/documentation/mkdocs.yml
@@ -47,6 +47,7 @@ nav:
       - Buttons: 'elements/buttons.md'
       - Code: 'elements/code.md'
       - Definitions: 'elements/definitions.md'
+      - Details: 'elements/details.md'
       - Figures: 'elements/figure.md'
       - Footnotes: 'elements/footnotes.md'
       - Links: 'elements/links.md'
@@ -75,6 +76,17 @@ markdown_extensions:
   - pymdownx.snippets:
       base_path: 
         - docs
+  - pymdownx.blocks.details:
+      types:
+        - name: info
+          class: terminal-alert
+          title: Info
+        - name: warning
+          class: terminal-alert-error
+          title: Warning
+        - name: important
+          class: terminal-alert-primary
+          title: Important
 
 plugins:
   - md-to-html


### PR DESCRIPTION
### Description

This PR adds documentation for the use of the PyMdown [details block](https://facelessuser.github.io/pymdown-extensions/extensions/blocks/plugins/details/) to MkDocs terminal. As MkDocs terminal ships with `terminal.css` it makes sense to use the three supported alert classes that come with that file: `terminal-alert`, `terminal-alert-error`, and `terminal-alert-primary`. The documentation also covers how to use custom classes if the user wishes to do so.


### References

Fixes #40 

### Testing

As there are no changes to the theme itself (as this is an optional extension to enable) there shouldn't be any testing required. I have run the yaml within the code block through a parser/prettier to make sure that there are no whitespace errors.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in [mkdocs-terminal/documentation](https://github.com/ntno/mkdocs-terminal/tree/main/documentation/docs)
- [x] All active GitHub checks for tests, formatting, and security are passing

