### PR TITLE
Add Details to palette examples

### DIFF
--- a/documentation/docs/configuration/extensions/pymdown-extensions.md
+++ b/documentation/docs/configuration/extensions/pymdown-extensions.md
@@ -131,7 +131,9 @@ markdown_extensions:
   [extra_css MkDocs feature]: https://www.mkdocs.org/user-guide/configuration/#extra_css
 
 See reference for usage:
+
 - [Adding Details]
+
   [Adding Details]: ../../../elements/details
 
 # Credit

--- a/documentation/docs/elements/details.md
+++ b/documentation/docs/elements/details.md
@@ -10,10 +10,10 @@ markdown_extensions:
           class: terminal-alert
           title: Info
         - name: warn
-          class: terminal-alert terminal-alert-error
+          class: 'terminal-alert terminal-alert-error'
           title: Warning
         - name: important
-          class: terminal-alert terminal-alert-primary
+          class: 'terminal-alert terminal-alert-primary'
           title: Important
 ```
 

--- a/documentation/docs/elements/details.md
+++ b/documentation/docs/elements/details.md
@@ -1,6 +1,6 @@
 # Details setup
 
-Enabling detail blocks requires the `pymdown.blocks.details` extension. Add it to the `markdown_extensions` configuration in `mkdocs.yml`:
+Enabling detail blocks requires the [pymdown.blocks.details extension]. Add it to the `markdown_extensions` configuration in `mkdocs.yml`:
 
 ```yaml
 markdown_extensions:
@@ -16,6 +16,8 @@ markdown_extensions:
           class: 'terminal-alert terminal-alert-primary'
           title: Important
 ```
+
+[pymdown.blocks.details extension]: ../../configuration/extensions/pymdown-extensions/#details
 
 # Example
 

--- a/documentation/docs/elements/examples/details.md
+++ b/documentation/docs/elements/examples/details.md
@@ -1,0 +1,15 @@
+## Details Example  
+
+/// info
+This is an info block
+///
+
+/// warning
+This is a warning
+///
+
+/// important
+This is important
+///
+
+<br>

--- a/documentation/docs/elements/examples/index.md
+++ b/documentation/docs/elements/examples/index.md
@@ -2,7 +2,6 @@
 elements/examples/typography.md
 elements/examples/code.md
 elements/examples/details.md
-elements/examples/buttons.md
 elements/examples/table.md
 elements/examples/footnotes.md
 elements/examples/links.md
@@ -11,4 +10,5 @@ elements/examples/figure.md
 elements/examples/definitions.md
 elements/examples/blockquotes.md
 elements/examples/tooltips.md
+elements/examples/buttons.md
 --8<--

--- a/documentation/docs/elements/examples/index.md
+++ b/documentation/docs/elements/examples/index.md
@@ -1,6 +1,7 @@
 --8<--
 elements/examples/typography.md
 elements/examples/code.md
+elements/examples/details.md
 elements/examples/buttons.md
 elements/examples/table.md
 elements/examples/footnotes.md


### PR DESCRIPTION
* adds new Details examples (#190) to the palette example pages:
* small formatting updates to existing documentation

<img width="1018" alt="Screen Shot 2025-03-01 at 10 46 07 AM" src="https://github.com/user-attachments/assets/29cc0fb2-9989-4faf-904f-7ba1ca6d8025" />
<img width="991" alt="Screen Shot 2025-03-01 at 10 46 16 AM" src="https://github.com/user-attachments/assets/35a46117-21c7-4613-8e5d-5542c35a0186" />
<img width="947" alt="Screen Shot 2025-03-01 at 10 46 25 AM" src="https://github.com/user-attachments/assets/6362f233-6f78-4a96-95d5-8f07648d21b6" />
