### PR TITLE
WIP - color palette toggle phase 1 patch

### DIFF
--- a/documentation/local.yml
+++ b/documentation/local.yml
@@ -4,7 +4,7 @@ theme:
   name: null
   custom_dir: '../terminal'
   palette:
-    default: dark
+    default: gruvbox_dark
     selector:
       enabled: true
       ui: auto

--- a/terminal/plugins/palette/plugin.py
+++ b/terminal/plugins/palette/plugin.py
@@ -65,7 +65,6 @@ class PalettePlugin(BasePlugin):
         )
 
         # Store for use in templates
-        #self.palette_config = palette_config
         config.theme.palette_config = palette_config
         config.theme.palette = palette_config["default"]
         return config

--- a/terminal/plugins/palette/plugin.py
+++ b/terminal/plugins/palette/plugin.py
@@ -65,30 +65,10 @@ class PalettePlugin(BasePlugin):
         )
 
         # Store for use in templates
-        self.palette_config = palette_config
-
+        #self.palette_config = palette_config
+        config.theme.palette_config = palette_config
+        config.theme.palette = palette_config["default"]
         return config
-
-    def on_env(self, env, config, files, **kwargs):
-        """Add palette configuration to Jinja2 environment.
-
-        Makes palette config available in templates as:
-        - config.palette_config
-
-        Args:
-            env: Jinja2 environment
-            config: MkDocs configuration
-            files: Site files
-
-        Returns:
-            Modified Jinja2 environment
-        """
-        # Add palette_config to template globals
-        if self.palette_config:
-            env.globals['palette_config'] = self.palette_config
-            logger.debug("Added palette_config to Jinja2 environment")
-
-        return env
 
 
 # Set up logging

--- a/tests/plugins/palette/test_palette_config.py
+++ b/tests/plugins/palette/test_palette_config.py
@@ -5,7 +5,6 @@ following MkDocs configuration patterns.
 """
 
 import pytest
-from pathlib import Path
 from terminal.plugins.palette.config import (
     parse_palette_config,
     validate_palette_options,
@@ -24,19 +23,19 @@ def theme_dir(tmp_path):
 
     # create directory including parent directories (-p flag)
     palettes_dir.mkdir(parents=True)
-    
+
     # Create bundled palette files from DEFAULT_PALETTES
     for palette in DEFAULT_PALETTES:
         palette_file = palettes_dir / f"{palette}.css"
         css_content = f"/* Test {palette} Palette */"
         palette_file.write_text(css_content)
-    
+
     return tmp_path
 
 
 class TestConfigClasses:
     """Test MkDocs Config classes for type validation."""
-    
+
     def test_palette_option_config(self):
         """Test PaletteOption Config class."""
         # Note: Config classes are used by MkDocs for validation
@@ -44,13 +43,13 @@ class TestConfigClasses:
         assert hasattr(PaletteOption, 'name')
         assert hasattr(PaletteOption, 'label')
         assert hasattr(PaletteOption, 'css')
-    
+
     def test_selector_config(self):
         """Test SelectorConfig Config class."""
         assert hasattr(SelectorConfig, 'enabled')
         assert hasattr(SelectorConfig, 'ui')
         assert hasattr(SelectorConfig, 'options')
-    
+
     def test_palette_config(self):
         """Test PaletteConfig Config class."""
         assert hasattr(PaletteConfig, 'default')
@@ -59,66 +58,64 @@ class TestConfigClasses:
 
 class TestLabelGeneration:
     """Tests for automatic label generation."""
-    
+
     def test_generate_label_from_underscored_name(self):
         """Test label generation converts underscores to spaces and title cases."""
         assert generate_label("gruvbox_dark") == "Gruvbox Dark"
         assert generate_label("sans_dark") == "Sans Dark"
         assert generate_label("red_drum") == "Red Drum"
-    
+
     def test_generate_label_from_hyphenated_name(self):
         """Test label generation converts hyphens to spaces."""
         assert generate_label("custom-theme") == "Custom Theme"
         assert generate_label("my-ocean") == "My Ocean"
-    
+
     def test_generate_label_from_simple_name(self):
         """Test label generation with single word."""
         assert generate_label("dark") == "Dark"
         assert generate_label("default") == "Default"
         assert generate_label("ocean") == "Ocean"
-    
+
     def test_generate_label_preserves_case_per_word(self):
         """Test label generation title cases each word."""
         assert generate_label("blueberry") == "Blueberry"
         assert generate_label("lightyear") == "Lightyear"
 
 
-
 class TestLegacyStringFormat:
     """Tests for legacy string format parsing."""
-    
+
     def test_legacy_string_dark(self, theme_dir):
         """Test palette: 'dark' normalizes correctly."""
         result = parse_palette_config("dark", theme_dir)
-        
+
         assert result["default"] == "dark"
         assert result["selector_enabled"] is False
         assert result["selector_ui"] == "auto"
         assert result["options"] == []
         assert "dark" in result["bundled_palettes"]
-    
+
     def test_legacy_string_default(self, theme_dir):
         """Test palette: 'default' normalizes correctly."""
         result = parse_palette_config("default", theme_dir)
-        
+
         assert result["default"] == "default"
         assert result["selector_enabled"] is False
-    
 
 
 class TestNewObjectFormat:
     """Tests for new object format parsing."""
-    
+
     def test_minimal_object_config(self, theme_dir):
         """Test minimal config with only default field."""
         config_value = {"default": "dark"}
         result = parse_palette_config(config_value, theme_dir)
-        
+
         assert result["default"] == "dark"
         assert result["selector_enabled"] is False
         assert result["selector_ui"] == "auto"
         assert result["options"] == []
-    
+
     def test_full_object_config(self, theme_dir):
         """Test full config with all fields."""
         config_value = {
@@ -133,14 +130,14 @@ class TestNewObjectFormat:
             }
         }
         result = parse_palette_config(config_value, theme_dir)
-        
+
         assert result["default"] == "dark"
         assert result["selector_enabled"] is True
         assert result["selector_ui"] == "select"
         assert len(result["options"]) == 2
         assert result["options"][0] == {"name": "dark", "label": "Dark"}
         assert result["options"][1] == {"name": "lightyear", "label": "Lightyear"}
-    
+
     def test_custom_palette_option(self, theme_dir):
         """Test config with custom palette CSS path."""
         config_value = {
@@ -152,11 +149,11 @@ class TestNewObjectFormat:
             }
         }
         result = parse_palette_config(config_value, theme_dir)
-        
+
         assert len(result["options"]) == 2
         assert result["options"][0] == {"name": "ocean", "label": "Ocean", "css": "assets/ocean.css"}
         assert result["options"][1] == {"name": "dark", "label": "Dark"}
-    
+
     def test_string_options_format(self, theme_dir):
         """Test simple string format for options."""
         config_value = {
@@ -165,12 +162,12 @@ class TestNewObjectFormat:
             }
         }
         result = parse_palette_config(config_value, theme_dir)
-        
+
         assert len(result["options"]) == 3
         assert result["options"][0] == {"name": "dark", "label": "Dark"}
         assert result["options"][1] == {"name": "lightyear", "label": "Lightyear"}
         assert result["options"][2] == {"name": "pink", "label": "Pink"}
-    
+
     def test_auto_derive_name_from_css_path(self, theme_dir):
         """Test automatic name derivation from CSS filename."""
         config_value = {
@@ -183,12 +180,12 @@ class TestNewObjectFormat:
             }
         }
         result = parse_palette_config(config_value, theme_dir)
-        
+
         assert len(result["options"]) == 3
         assert result["options"][0] == {"name": "ocean", "label": "Ocean", "css": "assets/ocean.css"}
         assert result["options"][1] == {"name": "custom-theme", "label": "Custom Theme", "css": "styles/custom-theme.css"}
         assert result["options"][2] == {"name": "dark", "label": "Dark"}
-    
+
     def test_explicit_name_overrides_css_basename(self, theme_dir):
         """Test that explicit name takes precedence over CSS basename."""
         config_value = {
@@ -199,10 +196,10 @@ class TestNewObjectFormat:
             }
         }
         result = parse_palette_config(config_value, theme_dir)
-        
+
         assert len(result["options"]) == 1
         assert result["options"][0] == {"name": "my-ocean", "label": "My Ocean", "css": "assets/ocean.css"}
-    
+
     def test_custom_label_for_palette(self, theme_dir):
         """Test user can specify custom UI label for palette."""
         config_value = {
@@ -215,12 +212,12 @@ class TestNewObjectFormat:
             }
         }
         result = parse_palette_config(config_value, theme_dir)
-        
+
         assert len(result["options"]) == 3
         assert result["options"][0] == {"name": "gruvbox_dark", "label": "Gruvbox Dark"}
         assert result["options"][1] == {"name": "sans_dark", "label": "Sans Serif Dark"}
         assert result["options"][2] == {"name": "dark", "label": "Dark"}
-    
+
     def test_auto_generated_label_for_underscored_names(self, theme_dir):
         """Test auto-generated labels convert underscores to spaces."""
         config_value = {
@@ -229,7 +226,7 @@ class TestNewObjectFormat:
             }
         }
         result = parse_palette_config(config_value, theme_dir)
-        
+
         assert len(result["options"]) == 3
         assert result["options"][0] == {"name": "gruvbox_dark", "label": "Gruvbox Dark"}
         assert result["options"][1] == {"name": "sans_dark", "label": "Sans Dark"}
@@ -238,30 +235,30 @@ class TestNewObjectFormat:
 
 class TestDefaultValues:
     """Tests for default value application."""
-    
+
     def test_none_config(self, theme_dir):
         """Test None config uses all defaults."""
         result = parse_palette_config(None, theme_dir)
-        
+
         assert result["default"] == "default"
         assert result["selector_enabled"] is False
         assert result["selector_ui"] == "auto"
         assert result["options"] == []
-    
+
     def test_empty_dict(self, theme_dir):
         """Test empty dict uses defaults."""
         result = parse_palette_config({}, theme_dir)
-        
+
         assert result["default"] == "default"
         assert result["selector_enabled"] is False
-    
+
     def test_missing_selector_fields(self, theme_dir):
         """Test missing selector fields use defaults."""
         config_value = {
             "selector": {}
         }
         result = parse_palette_config(config_value, theme_dir)
-        
+
         assert result["selector_enabled"] is False
         assert result["selector_ui"] == "auto"
         assert result["options"] == []
@@ -269,14 +266,14 @@ class TestDefaultValues:
 
 class TestEdgeCases:
     """Tests for edge cases and invalid input."""
-    
+
     def test_invalid_config_type(self, theme_dir):
         """Test invalid config type uses defaults."""
         result = parse_palette_config(123, theme_dir)
-        
+
         assert result["default"] == "default"
         assert result["selector_enabled"] is False
-    
+
     def test_invalid_selector_type(self, theme_dir):
         """Test invalid selector type uses defaults."""
         config_value = {
@@ -284,10 +281,10 @@ class TestEdgeCases:
             "selector": "invalid"
         }
         result = parse_palette_config(config_value, theme_dir)
-        
+
         assert result["default"] == "dark"
         assert result["selector_enabled"] is False
-    
+
     def test_invalid_ui_value(self, theme_dir):
         """Test invalid selector.ui value falls back to 'auto'."""
         config_value = {
@@ -296,9 +293,9 @@ class TestEdgeCases:
             }
         }
         result = parse_palette_config(config_value, theme_dir)
-        
+
         assert result["selector_ui"] == "auto"
-    
+
     def test_option_missing_both_name_and_css_skipped(self, theme_dir):
         """Test option without name or CSS is skipped."""
         config_value = {
@@ -311,11 +308,11 @@ class TestEdgeCases:
             }
         }
         result = parse_palette_config(config_value, theme_dir)
-        
+
         assert len(result["options"]) == 2
         assert result["options"][0]["name"] == "dark"
         assert result["options"][1]["name"] == "light"
-    
+
     def test_invalid_option_type_skipped(self, theme_dir):
         """Test invalid option types are skipped."""
         config_value = {
@@ -329,13 +326,13 @@ class TestEdgeCases:
             }
         }
         result = parse_palette_config(config_value, theme_dir)
-        
+
         assert len(result["options"]) == 2
 
 
 class TestValidation:
     """Tests for palette validation logic."""
-    
+
     def test_validate_bundled_palettes(self, theme_dir):
         """Test validation accepts valid bundled palettes."""
         config = parse_palette_config({
@@ -343,12 +340,12 @@ class TestValidation:
                 "options": ["dark", "lightyear", "blueberry"]
             }
         }, theme_dir)
-        
+
         result = validate_palette_options(config, [])
-        
+
         assert len(result["valid_options"]) == 3
         assert len(result["warnings"]) == 0
-    
+
     def test_validate_invalid_bundled_palette(self, theme_dir):
         """Test validation rejects non-existent bundled palette."""
         config = parse_palette_config({
@@ -356,12 +353,12 @@ class TestValidation:
                 "options": ["blueberry", "nonexistent", "lightyear"]
             }
         }, theme_dir)
-        
+
         result = validate_palette_options(config, [])
-        
+
         assert len(result["valid_options"]) == 2
         assert any("nonexistent" in w for w in result["warnings"])
-    
+
     def test_validate_custom_palette_in_extra_css(self, theme_dir):
         """Test validation accepts custom palette in extra_css."""
         config = parse_palette_config({
@@ -372,12 +369,12 @@ class TestValidation:
                 ]
             }
         }, theme_dir)
-        
+
         result = validate_palette_options(config, ["assets/ocean.css"])
-        
+
         assert len(result["valid_options"]) == 2
         assert len(result["warnings"]) == 0
-    
+
     def test_validate_custom_palette_missing_from_extra_css(self, theme_dir):
         """Test validation rejects custom palette not in extra_css."""
         config = parse_palette_config({
@@ -388,13 +385,13 @@ class TestValidation:
                 ]
             }
         }, theme_dir)
-        
+
         result = validate_palette_options(config, [])
-        
+
         assert len(result["valid_options"]) == 1
         assert result["valid_options"][0]["name"] == "dark"
         assert any("ocean.css" in w for w in result["warnings"])
-    
+
     def test_validate_custom_palette_overrides_bundled_name(self, theme_dir):
         """Test user can create custom palette with same name as bundled palette."""
         config = parse_palette_config({
@@ -405,16 +402,16 @@ class TestValidation:
                 ]
             }
         }, theme_dir)
-        
+
         result = validate_palette_options(config, ["my-custom-dark.css"])
-        
+
         # Both options should be valid
         assert len(result["valid_options"]) == 2
         # Custom palette should be treated as custom (not bundled)
         assert result["valid_options"][0] == {"name": "dark", "label": "Dark", "css": "my-custom-dark.css"}
         assert result["valid_options"][1] == {"name": "default", "label": "Default"}
         assert len(result["warnings"]) == 0
-    
+
     def test_validate_invalid_default_palette(self, theme_dir):
         """Test validation fixes invalid default palette."""
         config = parse_palette_config({
@@ -423,12 +420,12 @@ class TestValidation:
                 "options": ["dark", "red_drum"]
             }
         }, theme_dir)
-        
+
         result = validate_palette_options(config, [])
-        
+
         assert result["default"] == "default"  # Falls back
         assert any("nonexistent" in w for w in result["warnings"])
-    
+
     def test_validate_duplicate_palette_names_keeps_first_valid(self, theme_dir):
         """Test duplicate palette names - keeps first valid occurrence."""
         config = parse_palette_config({
@@ -440,16 +437,16 @@ class TestValidation:
                 ]
             }
         }, theme_dir)
-        
+
         result = validate_palette_options(config, [])
-        
+
         # Should only have 2 valid options (dark, default)
         assert len(result["valid_options"]) == 2
         assert result["valid_options"][0]["name"] == "dark"
         assert result["valid_options"][1]["name"] == "default"
         # Should have warning about duplicate
         assert any("Duplicate palette name 'dark'" in w for w in result["warnings"])
-    
+
     def test_validate_duplicate_names_skips_invalid_uses_next_valid(self, theme_dir):
         """Test duplicate names - if first is invalid, use next valid occurrence."""
         config = parse_palette_config({
@@ -461,9 +458,9 @@ class TestValidation:
                 ]
             }
         }, theme_dir)
-        
+
         result = validate_palette_options(config, ["valid.css"])
-        
+
         # Should have 2 valid options (custom with valid.css, default)
         assert len(result["valid_options"]) == 2
         assert result["valid_options"][0] == {"name": "custom", "css": "valid.css", "label": "Custom"}
@@ -472,7 +469,7 @@ class TestValidation:
         assert any("missing.css" in w for w in result["warnings"])
         # Should NOT have duplicate warning (first was invalid, didn't get added)
         assert not any("Duplicate palette name" in w for w in result["warnings"])
-    
+
     def test_validate_duplicate_bundled_and_custom_palette(self, theme_dir):
         """Test duplicate where first is valid bundled, second is custom."""
         config = parse_palette_config({
@@ -484,16 +481,16 @@ class TestValidation:
                 ]
             }
         }, theme_dir)
-        
+
         result = validate_palette_options(config, ["my-dark.css"])
-        
+
         # Should keep first valid occurrence (bundled dark)
         assert len(result["valid_options"]) == 2
         assert result["valid_options"][0] == {"name": "dark", "label": "Dark"}  # No CSS = bundled
         assert result["valid_options"][1] == {"name": "default", "label": "Default"}
         # Should warn about duplicate
         assert any("Duplicate palette name 'dark'" in w for w in result["warnings"])
-    
+
     def test_validate_selector_disabled_when_no_valid_options(self, theme_dir):
         """Test selector disabled when all options are invalid."""
         config = parse_palette_config({
@@ -502,13 +499,13 @@ class TestValidation:
                 "options": ["invalid1", "invalid2"]
             }
         }, theme_dir)
-        
+
         result = validate_palette_options(config, [])
-        
+
         assert result["selector_enabled"] is False
         assert len(result["valid_options"]) == 0
         assert any("Disabling selector" in w for w in result["warnings"])
-    
+
     def test_validate_toggle_ui_requires_two_options(self, theme_dir):
         """Test toggle UI validation requires exactly 2 options."""
         config = parse_palette_config({
@@ -518,12 +515,12 @@ class TestValidation:
                 "options": ["dark", "lightyear", "pink"]
             }
         }, theme_dir)
-        
+
         result = validate_palette_options(config, [])
-        
+
         assert result["selector_ui"] == "select"  # Falls back
         assert any("Toggle UI requires exactly 2" in w for w in result["warnings"])
-    
+
     def test_validate_toggle_ui_with_two_options(self, theme_dir):
         """Test toggle UI accepted with exactly 2 options."""
         config = parse_palette_config({
@@ -533,12 +530,12 @@ class TestValidation:
                 "options": ["dark", "lightyear"]
             }
         }, theme_dir)
-        
+
         result = validate_palette_options(config, [])
-        
+
         assert result["selector_ui"] == "toggle"
         assert len(result["warnings"]) == 0
-    
+
     def test_validate_select_ui_with_two_options(self, theme_dir):
         """Test user can explicitly choose select UI even with 2 options."""
         config = parse_palette_config({
@@ -548,30 +545,30 @@ class TestValidation:
                 "options": ["sans_dark", "sans"]
             }
         }, theme_dir)
-        
+
         result = validate_palette_options(config, [])
-        
+
         assert result["selector_ui"] == "select"
         assert len(result["warnings"]) == 0
 
 
 class TestBundledPalettesDetection:
     """Tests for detecting available bundled palettes."""
-    
+
     def test_detects_bundled_palettes(self, theme_dir):
         """Test detection of palette CSS files."""
         result = parse_palette_config(None, theme_dir)
-        
+
         bundled = result["bundled_palettes"]
-        
+
         # Verify all DEFAULT_PALETTES are detected
         for palette in DEFAULT_PALETTES:
             assert palette in bundled, f"Expected palette '{palette}' not found in bundled palettes"
-        
+
         assert len(bundled) == len(DEFAULT_PALETTES)
-    
+
     def test_handles_missing_palettes_directory(self, tmp_path):
         """Test graceful handling when palettes directory doesn't exist."""
         result = parse_palette_config(None, tmp_path)
-        
+
         assert result["bundled_palettes"] == []

--- a/tests/plugins/palette/test_palette_plugin.py
+++ b/tests/plugins/palette/test_palette_plugin.py
@@ -129,38 +129,6 @@ class TestOnConfig:
         assert plugin.palette_config["valid_options"][0]["name"] == "ocean"
 
 
-class TestOnEnv:
-    """Tests for on_env event handler."""
-    
-    def test_on_env_adds_palette_config_to_globals(self, mock_mkdocs_config):
-        """Test on_env adds palette_config to Jinja2 globals."""
-        plugin = PalettePlugin()
-        plugin.on_config(mock_mkdocs_config)
-        
-        # Create mock Jinja2 environment
-        env = MagicMock()
-        env.globals = {}
-        
-        result = plugin.on_env(env, mock_mkdocs_config, None)
-        
-        assert result == env
-        assert "palette_config" in env.globals
-        assert env.globals["palette_config"] == plugin.palette_config
-    
-    def test_on_env_handles_no_palette_config(self, mock_mkdocs_config):
-        """Test on_env handles case when palette_config is None."""
-        plugin = PalettePlugin()
-        # Don't call on_config, so palette_config remains None
-        
-        env = MagicMock()
-        env.globals = {}
-        
-        result = plugin.on_env(env, mock_mkdocs_config, None)
-        
-        assert result == env
-        assert "palette_config" not in env.globals
-
-
 class TestPluginIntegration:
     """Integration tests for plugin lifecycle."""
     

--- a/tests/plugins/palette/test_palette_plugin.py
+++ b/tests/plugins/palette/test_palette_plugin.py
@@ -5,8 +5,7 @@ handling, and Jinja2 environment setup.
 """
 
 import pytest
-from unittest.mock import MagicMock, PropertyMock
-from pathlib import Path
+from unittest.mock import MagicMock
 from terminal.plugins.palette.plugin import PalettePlugin
 
 
@@ -17,24 +16,24 @@ def mock_mkdocs_config(tmp_path):
     theme_dir = tmp_path / "theme"
     palettes_dir = theme_dir / "css" / "palettes"
     palettes_dir.mkdir(parents=True)
-    
+
     # Create palette files
     for palette in ["default", "dark", "lightyear"]:
         palette_file = palettes_dir / f"{palette}.css"
         css_content = f"/* Test {palette} Palette */"
         palette_file.write_text(css_content)
-    
+
     config = MagicMock()
     config.theme.dirs = [str(theme_dir)]
     config.theme.get = MagicMock(return_value=None)
     config.extra_css = []
-    
+
     return config
 
 
 class TestPalettePluginInitialization:
     """Tests for plugin initialization."""
-    
+
     def test_plugin_initialization(self):
         """Test plugin initializes with None palette_config."""
         plugin = PalettePlugin()
@@ -43,27 +42,27 @@ class TestPalettePluginInitialization:
 
 class TestOnConfig:
     """Tests for on_config event handler."""
-    
+
     def test_on_config_with_no_palette_config(self, mock_mkdocs_config):
         """Test on_config with no palette configuration."""
         plugin = PalettePlugin()
         result = plugin.on_config(mock_mkdocs_config)
-        
+
         assert result == mock_mkdocs_config
-        assert plugin.palette_config is not None
-        assert plugin.palette_config["default"] == "default"
-        assert plugin.palette_config["selector_enabled"] is False
-    
+        assert mock_mkdocs_config.theme.palette_config is not None
+        assert mock_mkdocs_config.theme.palette_config["default"] == "default"
+        assert mock_mkdocs_config.theme.palette_config["selector_enabled"] is False
+
     def test_on_config_with_legacy_string(self, mock_mkdocs_config):
         """Test on_config with legacy string format."""
         mock_mkdocs_config.theme.get = MagicMock(return_value="dark")
-        
+
         plugin = PalettePlugin()
         plugin.on_config(mock_mkdocs_config)
-        
-        assert plugin.palette_config["default"] == "dark"
-        assert plugin.palette_config["selector_enabled"] is False
-    
+
+        assert mock_mkdocs_config.theme.palette_config["default"] == "dark"
+        assert mock_mkdocs_config.theme.palette_config["selector_enabled"] is False
+
     def test_on_config_with_new_format(self, mock_mkdocs_config):
         """Test on_config with new object format."""
         palette_config = {
@@ -78,15 +77,15 @@ class TestOnConfig:
             }
         }
         mock_mkdocs_config.theme.get = MagicMock(return_value=palette_config)
-        
+
         plugin = PalettePlugin()
         plugin.on_config(mock_mkdocs_config)
-        
-        assert plugin.palette_config["default"] == "dark"
-        assert plugin.palette_config["selector_enabled"] is True
-        assert plugin.palette_config["selector_ui"] == "toggle"
-        assert len(plugin.palette_config["valid_options"]) == 2
-    
+
+        assert mock_mkdocs_config.theme.palette_config["default"] == "dark"
+        assert mock_mkdocs_config.theme.palette_config["selector_enabled"] is True
+        assert mock_mkdocs_config.theme.palette_config["selector_ui"] == "toggle"
+        assert len(mock_mkdocs_config.theme.palette_config["valid_options"]) == 2
+
     def test_on_config_validates_options(self, mock_mkdocs_config):
         """Test on_config validates palette options."""
         palette_config = {
@@ -100,15 +99,15 @@ class TestOnConfig:
             }
         }
         mock_mkdocs_config.theme.get = MagicMock(return_value=palette_config)
-        
+
         plugin = PalettePlugin()
         plugin.on_config(mock_mkdocs_config)
-        
+
         # Invalid palette should be filtered out
-        assert len(plugin.palette_config["valid_options"]) == 2
-        assert plugin.palette_config["valid_options"][0]["name"] == "dark"
-        assert plugin.palette_config["valid_options"][1]["name"] == "lightyear"
-    
+        assert len(mock_mkdocs_config.theme.palette_config["valid_options"]) == 2
+        assert mock_mkdocs_config.theme.palette_config["valid_options"][0]["name"] == "dark"
+        assert mock_mkdocs_config.theme.palette_config["valid_options"][1]["name"] == "lightyear"
+
     def test_on_config_with_custom_palette(self, mock_mkdocs_config):
         """Test on_config with custom palette in extra_css."""
         palette_config = {
@@ -121,43 +120,9 @@ class TestOnConfig:
         }
         mock_mkdocs_config.theme.get = MagicMock(return_value=palette_config)
         mock_mkdocs_config.extra_css = ["assets/ocean.css"]
-        
+
         plugin = PalettePlugin()
         plugin.on_config(mock_mkdocs_config)
-        
-        assert len(plugin.palette_config["valid_options"]) == 2
-        assert plugin.palette_config["valid_options"][0]["name"] == "ocean"
 
-
-class TestPluginIntegration:
-    """Integration tests for plugin lifecycle."""
-    
-    def test_full_plugin_lifecycle(self, mock_mkdocs_config):
-        """Test complete plugin lifecycle: init -> on_config -> on_env."""
-        # Initialize plugin
-        plugin = PalettePlugin()
-        assert plugin.palette_config is None
-        
-        # Process config
-        palette_config = {
-            "default": "dark",
-            "selector": {
-                "enabled": True,
-                "ui": "auto",
-                "options": ["dark", "lightyear"]
-            }
-        }
-        mock_mkdocs_config.theme.get = MagicMock(return_value=palette_config)
-        plugin.on_config(mock_mkdocs_config)
-        
-        assert plugin.palette_config is not None
-        assert plugin.palette_config["default"] == "dark"
-        
-        # Setup Jinja2 environment
-        env = MagicMock()
-        env.globals = {}
-        plugin.on_env(env, mock_mkdocs_config, None)
-        
-        assert "palette_config" in env.globals
-        assert env.globals["palette_config"]["default"] == "dark"
-        assert env.globals["palette_config"]["selector_enabled"] is True
+        assert len(mock_mkdocs_config.theme.palette_config["valid_options"]) == 2
+        assert mock_mkdocs_config.theme.palette_config["valid_options"][0]["name"] == "ocean"


### PR DESCRIPTION
- remove `on_env` from plugin 
- NOTE: still slightly broken but less broken than before (fallback to default/terminal palette is not working when you have an inline style set)