### PR TITLE
chore: switch mkdocs dependency to mkdocs-ng

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 jinja2>=2.10
-mkdocs>=1.4.2
+mkdocs-ng
 markdown
 pygments
 pymdown-extensions


### PR DESCRIPTION
Hi, this is a small PR to suggest switching the `mkdocs` dependency to `mkdocs-ng`.

The `mkdocs` package on PyPI is currently unmaintained — see [Is MkDocs still maintained?](https://github.com/mkdocs/mkdocs/discussions/4010) and [The Slow Collapse of MkDocs](https://fpgmaas.com/blog/collapse-of-mkdocs/) for context.

[`mkdocs-ng`](https://pypi.org/project/mkdocs-ng/) is a community-maintained fork that:
- Keeps the same `mkdocs` CLI — no changes for end users
- Adds Python 3.13 / 3.14 support
- Includes bug fixes and active development
- One-line drop-in replacement

```diff
- mkdocs
+ mkdocs-ng
```

No obligation — just sharing in case it's helpful. Thanks!